### PR TITLE
Feature/docs clean up

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ oc login -u developer -p developer
 
 ## Actual deployment
 
-Manually create a mysql container in openshift, make note of the db name, username and password, and put those into the client_test.json envVars section.
+Manually create a mysql container in OpenShift, make note of the db name, username and password, and put those into the client_test.json envVars section.
 
 ### Test clean up scripts 
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -970,7 +970,7 @@ class Client implements ClientInterface {
     }
 
     if (!empty($probes)) {
-      $deploymentConfig['spec']['template']['spec']['containers'][0] =
+      $deploymentConfig['spec']['template']['spec']['containers'][0] +=
         $this->generateProbeConfigs($probes);
     }
 

--- a/src/Client.php
+++ b/src/Client.php
@@ -983,64 +983,6 @@ class Client implements ClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function addProbeConfig(&$deployment_config, $probes) {
-    foreach (['liveness', 'readiness'] as $type) {
-      if (!empty($probes[$type])) {
-        $deployment_config['spec']['template']['spec']['containers'][0][$type . 'Probe'] =
-          $this->probeConfig($probes[$type]);
-      }
-    }
-  }
-
-  /**
-   * Generates probe configuration based on probe type.
-   *
-   * @param array $probe
-   *   A single probe configuration array.
-   *
-   * @return array
-   *   Config array to be added to the Deployment Config.
-   */
-  protected function probeConfig(array $probe) {
-    $probeConfig = [];
-    switch ($probe['type']) {
-      case 'exec':
-        $probeConfig = [
-          'initialDelaySeconds' => 10,
-          'timeoutSeconds' => 10,
-          'exec' => [
-            'command' => explode(' ', $probe['parameters']),
-          ],
-        ];
-        break;
-
-      case 'httpGet':
-        $probeConfig = [
-          'initialDelaySeconds' => 10,
-          'timeoutSeconds' => 10,
-          'httpGet' => [
-            'port' => (int) $probe['port'],
-            'path' => $probe['parameters'],
-          ],
-        ];
-        break;
-
-      case 'tcpSocket':
-        $probeConfig = [
-          'initialDelaySeconds' => 10,
-          'timeoutSeconds' => 10,
-          'tcpSocket' => [
-            'port' => (int) $probe['port'],
-          ],
-        ];
-        break;
-    }
-    return $probeConfig;
-  }
-
-  /**
-   * {@inheritdoc}
-   */
   public function createDeploymentConfig(array $deploymentConfig) {
     $resourceMethod = $this->getResourceMethod(__METHOD__);
     $uri = $this->createRequestUri($resourceMethod['uri']);

--- a/src/Client.php
+++ b/src/Client.php
@@ -731,15 +731,9 @@ class Client implements ClientInterface {
   }
 
   /**
-   * Formats image stream config as an array.
-   *
-   * @param string $name
-   *   The name of the image stream.
-   *
-   * @return array
-   *   Formatted array of image stream config.
+   * {@inheritdoc}
    */
-  protected function generateImageStreamConfig(string $name) {
+  public function generateImageStreamConfig(string $name) {
     $imageStream = [
       'apiVersion' => 'v1',
       'kind' => 'ImageStream',
@@ -760,12 +754,10 @@ class Client implements ClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function createImageStream(string $name) {
+  public function createImageStream(array $image_stream_config) {
     $resourceMethod = $this->getResourceMethod(__METHOD__);
 
-    $imageStreamConfig = $this->generateImageStreamConfig($name);
-
-    return $this->request($resourceMethod['action'], $this->createRequestUri($resourceMethod['uri']), $imageStreamConfig);
+    return $this->request($resourceMethod['action'], $this->createRequestUri($resourceMethod['uri']), $image_stream_config);
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -1305,7 +1305,7 @@ class Client implements ClientInterface {
   }
 
   /**
-   * Given an array of volumes, structure it into an array for openshift.
+   * Given an array of volumes, structure it into an array for OpenShift.
    *
    * @param array $volumes
    *   The array of volumes to format.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -619,14 +619,14 @@ interface ClientInterface {
   public function getDeploymentConfigs(string $label);
 
   /**
-   * Add probe configuration
+   * Add probe configuration.
    *
    * @param array $deployment_config
    *   The Deployment config that you want to add probes to.
-   * @param $probes
+   * @param array $probes
    *   An array of probe configuration to add to the DeploymentConfig.
    */
-  public function addProbeConfig(&$deployment_config, $probes);
+  public function addProbeConfig(array &$deployment_config, array $probes);
 
   /**
    * Retrieve a cron job.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -342,10 +342,21 @@ interface ClientInterface {
   public function getImageStream(string $name);
 
   /**
-   * Creates an image stream.
+   * Formats image stream config as an array.
    *
    * @param string $name
-   *   Name of image stream.
+   *   The name of the image stream.
+   *
+   * @return array
+   *   Formatted array of image stream config.
+   */
+  public function generateImageStreamConfig(string $name);
+
+  /**
+   * Creates an image stream.
+   *
+   * @param array $image_stream_config
+   *   Image stream configuration E.g. generateImageStreamConfig().
    *
    * @return array
    *   Returns the body response if successful.
@@ -353,7 +364,7 @@ interface ClientInterface {
    * @throws ClientException
    *   Throws exception if there is an issue updating image stream.
    */
-  public function createImageStream(string $name);
+  public function createImageStream(array $image_stream_config);
 
   /**
    * Updates an image stream.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -619,16 +619,6 @@ interface ClientInterface {
   public function getDeploymentConfigs(string $label);
 
   /**
-   * Add probe configuration
-   *
-   * @param array $deployment_config
-   *   The Deployment config that you want to add probes to.
-   * @param $probes
-   *   An array of probe configuration to add to the DeploymentConfig.
-   */
-  public function addProbeConfig(&$deployment_config, $probes);
-
-  /**
    * Retrieve a cron job.
    *
    * @param string $name

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -504,7 +504,10 @@ interface ClientInterface {
   public function deletePersistentVolumeClaim(string $name);
 
   /**
-   * Create a deployment config on the openshift instance.
+   * Create a deployment config on the OpenShift instance.
+   *
+   * N.B. This is just the configuration for the deployment. Triggering a
+   * deployment relies on instantiateDeploymentConfig().
    *
    * @param array $deploymentConfig
    *   The deployment config array.
@@ -518,11 +521,21 @@ interface ClientInterface {
   public function createDeploymentConfig(array $deploymentConfig);
 
   /**
-   * Trigger a deployment config
+   * Trigger "deployment" for a given deployment config.
+   *
+   * If the image stream does not have an image available (still building) when
+   * you instantiate a deployment, an exception will be thrown. It is
+   * recommended to inspect the phase of a build to determine if an image is
+   * available.
    *
    * @param string $name
+   *   Label name of deployment configs to retrieve.
    *
    * @return mixed
+   *   Returns the body response if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue instantiating deployment config.
    */
   public function instantiateDeploymentConfig(string $name);
 

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -619,6 +619,16 @@ interface ClientInterface {
   public function getDeploymentConfigs(string $label);
 
   /**
+   * Add probe configuration
+   *
+   * @param array $deployment_config
+   *   The Deployment config that you want to add probes to.
+   * @param $probes
+   *   An array of probe configuration to add to the DeploymentConfig.
+   */
+  public function addProbeConfig(&$deployment_config, $probes);
+
+  /**
    * Retrieve a cron job.
    *
    * @param string $name

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -156,16 +156,6 @@ interface ClientInterface {
   public function updateService(string $name, string $selector);
 
   /**
-   * Group services together in the UI.
-   *
-   * @param string $app_name
-   *   The application being deployed, that this service is part of.
-   * @param string $name
-   *   The service name being deployed.
-   */
-  public function groupService(string $app_name, string $name);
-
-  /**
    * Deletes a named service.
    *
    * @param string $name
@@ -178,6 +168,16 @@ interface ClientInterface {
    *   Throws exception if there is an issue deleting service.
    */
   public function deleteService(string $name);
+
+  /**
+   * Group services together in the UI.
+   *
+   * @param string $app_name
+   *   The application being deployed, that this service is part of.
+   * @param string $name
+   *   The service name being deployed.
+   */
+  public function groupService(string $app_name, string $name);
 
   /**
    * Gets all routes for the current working namespace.
@@ -260,20 +260,6 @@ interface ClientInterface {
   public function getBuildConfig(string $name);
 
   /**
-   * Retrieves the builds by label name.
-   *
-   * @param string $name
-   *   Name of build config to get builds for.
-   *
-   * @return array|bool
-   *   Returns the body response if successful, false if it does not exist.
-   *
-   * @throws ClientException
-   *   Throws exception if there is an issue retrieving build config.
-   */
-  public function getBuilds(string $name);
-
-  /**
    * Create build config.
    *
    * @param string $name
@@ -328,6 +314,20 @@ interface ClientInterface {
   public function deleteBuildConfig(string $name);
 
   /**
+   * Retrieves the builds by label name.
+   *
+   * @param string $name
+   *   Name of build config to get builds for.
+   *
+   * @return array|bool
+   *   Returns the body response if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue retrieving build config.
+   */
+  public function getBuilds(string $name);
+
+  /**
    * Retrieves all image streams under current namespace.
    *
    * @param string $name
@@ -342,32 +342,24 @@ interface ClientInterface {
   public function getImageStream(string $name);
 
   /**
-   * Creates an image stream, needed for buildConfig.
+   * Creates an image stream.
    *
    * @param string $name
-   *   Name of image stream to create.
+   *   Name of image stream.
    *
-   * @return array Returns the body response if successful.
+   * @return array
    *   Returns the body response if successful.
-   */
-  public function generateImageStream(string $name);
-
-  /**
-   * Creates an image stream from the passing in array specification.
    *
-   * @param array $imageStreamConfig
-   *   An image stream specification as an array.
-   *
-   * @return array Returns the body response if successful.
-   *   Returns the body response if successful.
+   * @throws ClientException
+   *   Throws exception if there is an issue updating image stream.
    */
-  public function createImageStream(array $imageStreamConfig);
+  public function createImageStream(string $name);
 
   /**
    * Updates an image stream.
    *
    * @param string $name
-   *   Name of imagestream to update.
+   *   Name of image stream to update.
    *
    * @return array
    *   Returns the body response if successful.
@@ -512,9 +504,11 @@ interface ClientInterface {
   public function deletePersistentVolumeClaim(string $name);
 
   /**
-   * Create a deployment config on the openshift instance
+   * Create a deployment config on the openshift instance.
    *
    * @param array $deploymentConfig
+   *   The deployment config array.
+   *
    * @return array
    *   Returns the body response if successful.
    *

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -568,11 +568,13 @@ interface ClientInterface {
    *   Volumes to attach to the deployment config.
    * @param array $data
    *   Configuration data for deployment config.
+   * @param array $probes
+   *   Probe configuration.
    *
    * @return array
    *   Returns the body response if successful.
    */
-  public function generateDeploymentConfig(string $name, string $image_stream_tag, string $image_name, bool $update_on_image_change, array $volumes, array $data);
+  public function generateDeploymentConfig(string $name, string $image_stream_tag, string $image_name, bool $update_on_image_change, array $volumes, array $data, array $probes);
 
   /**
    * Updates and existing deployment config.
@@ -617,16 +619,6 @@ interface ClientInterface {
    *   Throws exception if there is an issue retrieving deployment configs.
    */
   public function getDeploymentConfigs(string $label);
-
-  /**
-   * Add probe configuration.
-   *
-   * @param array $deployment_config
-   *   The Deployment config that you want to add probes to.
-   * @param array $probes
-   *   An array of probe configuration to add to the DeploymentConfig.
-   */
-  public function addProbeConfig(array &$deployment_config, array $probes);
 
   /**
    * Retrieve a cron job.


### PR DESCRIPTION
API break: Removes addProbeConfig(). Probes should be supplied as part of a deployment config.

API break: generateProbeConfigs() is now internal. You don't need to "generate" and then pass the config in. generateDeploymentConfig() just calls generateProbeConfigs().

Cleans up much docs... phpcs fixes and a few things that weren't clear to me.