### PR TITLE
Improve client exception thrown

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -353,12 +353,12 @@ class Client implements ClientInterface {
       if ($method === 'GET' && $e->getCode() === 404) {
         return FALSE;
       }
-      // Do some special decoding for OpenShift
+      // Do some special decoding for OpenShift.
       if ($e->hasResponse()) {
         $message = json_decode($e->getResponse()->getBody()->getContents());
       }
       throw new ClientException(
-        isset($message) ? $message->message : '',
+        isset($message) ? $message->message : $e->getMessage(),
         $e->getCode(),
         $e->getPrevious(),
         $e->hasResponse() ? $e->getResponse()->getBody() : ''


### PR DESCRIPTION
If `$message`  from the response body is empty, use `getMessage()` instead of returning an empty string. That way a message will always be thrown with the exception, improving error messages for thing like : 
SSL Certificate errors that return no body response and a `0` status code but does return a detailed curl error `message`. 