### PR TITLE
Default to 0 memory allocated to prevent exhausting cluster memory.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -937,7 +937,13 @@ class Client implements ClientInterface {
                       [
                         'limits' =>
                           [
-                            'memory' => isset($data['memory_limit']) ? $data['memory_limit'] : '',
+                            'cpu' => $data['cpu_limit'] ?? '',
+                            'memory' => $data['memory_limit'] ?? '0',
+                          ],
+                        'requests' =>
+                          [
+                            'cpu' => $data['cpu_request'] ?? '',
+                            'memory' => $data['memory_request'] ?? '0',
                           ],
                       ],
                     'volumeMounts' => $volume_config['mounts'],


### PR DESCRIPTION
Memory request defaults to the memory limit, meaning memory is permanently allocated to each pod. Instead, set request memory to 0 - no allocation, only a limit.
CPU limit and request support also added.

I.e. if request is not set, it defaults to the value for limit.