### PR TITLE
Feature/implement deploymentconfigs method

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -874,7 +874,7 @@ class Client implements ClientInterface {
    * {@inheritdoc}
    */
   public function getDeploymentConfigs(string $label = NULL) {
-    // If there is no labelSelector retrive all in the namespace.
+    // If there is no labelSelector retrieve all in the namespace.
     return $this->apiCall(__METHOD__, '', $label);
   }
 
@@ -1085,14 +1085,14 @@ class Client implements ClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function updateDeploymentConfig(string $name, array $deploymentConfig, array $config) {
-    $deploymentConfig = array_replace_recursive($deploymentConfig, $config);
+  public function updateDeploymentConfig(string $name, array $deployment_config, array $config) {
+    $deployment_config = array_replace_recursive($deployment_config, $config);
     $resourceMethod = $this->getResourceMethod(__METHOD__);
     $uri = $this->createRequestUri($resourceMethod['uri'], [
       'name' => (string) $name,
     ]);
 
-    return $this->request($resourceMethod['action'], $uri, $deploymentConfig);
+    return $this->request($resourceMethod['action'], $uri, $deployment_config);
   }
 
   /**

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -609,7 +609,7 @@ interface ClientInterface {
    *
    * @param string $name
    *   Name of the deploymentconfig.
-   * @param array $deploymentConfig
+   * @param array $deployment_config
    *   The deployment config you wish to update.
    * @param array $config
    *   The config updates you want to apply to deploymentConfig.
@@ -620,7 +620,7 @@ interface ClientInterface {
    * @throws ClientException
    *   Throws exception if there is an issue updating deployment config.
    */
-  public function updateDeploymentConfig(string $name, array $deploymentConfig, array $config);
+  public function updateDeploymentConfig(string $name, array $deployment_config, array $config);
 
   /**
    * Deletes a deployment config by name.


### PR DESCRIPTION
Updated the `getDeploymentConfigs` method. A null label will return all the deploymentConfigs of the current namespace. 

Refactored the `updateDeploymentConfig` method to update an existing deploymentConfig based on a supplied array of configuration. This way we are not hardwiring anything ( ie replica_count ), make it more flexible for the future where we need to update multiple parts of a deploymentConfig. 