### PR TITLE
Update apiVersion for cron job resources

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -76,19 +76,19 @@ class Client implements ClientInterface {
     'cronjob' => [
       'create' => [
         'action' => 'POST',
-        'uri'    => '/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs',
+        'uri'    => '/apis/batch/v1beta1/namespaces/{namespace}/cronjobs',
       ],
       'delete' => [
         'action' => 'DELETE',
-        'uri'    => '/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}',
+        'uri'    => '/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}',
       ],
       'get' => [
         'action' => 'GET',
-        'uri'    => '/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}',
+        'uri'    => '/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}',
       ],
       'update' => [
         'action' => 'PUT',
-        'uri'    => '/apis/batch/v2alpha1/namespaces/{namespace}/cronjobs/{name}',
+        'uri'    => '/apis/batch/v1beta1/namespaces/{namespace}/cronjobs/{name}',
       ],
     ],
     'deploymentconfig' => [
@@ -1129,7 +1129,7 @@ class Client implements ClientInterface {
     $job_template = $this->jobTemplate($name, $image_name, $args, $volume_config, $data);
 
     $cronConfig = [
-      'apiVersion' => 'batch/v2alpha1',
+      'apiVersion' => 'batch/v1beta1',
       'kind' => 'CronJob',
       'metadata' => [
         'name' => $name,


### PR DESCRIPTION
As per the documentation, both 3.9 and 3.10 use this api version

https://docs.openshift.com/container-platform/3.9/dev_guide/cron_jobs.html
https://docs.openshift.com/container-platform/3.10/dev_guide/cron_jobs.html