### PR TITLE
Heptio Ark Backup/Restore Support + Sync operator support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
         }
     ],
     "require": {
-        "guzzlehttp/guzzle" : "^6.2.1"
+        "guzzlehttp/guzzle" : "^6.2.1",
+        "symfony/serializer": "~3.4.0"
     },
     "require-dev": {
         "phpunit/phpunit" : "~4.0",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<phpunit bootstrap="tests/bootstrap.php" colors="true"
+         beStrictAboutTestsThatDoNotTestAnything="true"
+         beStrictAboutOutputDuringTests="true"
+         beStrictAboutChangesToGlobalState="true"
+         checkForUnintentionallyCoveredCode="false">
+    <php>
+        <!-- Set error reporting to E_ALL. -->
+        <ini name="error_reporting" value="32767"/>
+        <!-- Do not limit the amount of memory tests take to run. -->
+        <ini name="memory_limit" value="-1"/>
+        <const name="BOOTSTRAP_IS_PHPUNIT" value="true"/>
+    </php>
+    <testsuites>
+        <testsuite name="unit">
+            <directory>./tests/Unit</directory>
+        </testsuite>
+    </testsuites>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener">
+        </listener>
+    </listeners>
+    <!-- Filter for coverage reports. -->
+    <filter>
+        <whitelist>
+            <directory>./src</directory>
+            <!-- By definition test classes have no tests. -->
+            <exclude>
+                <directory suffix="Test.php">./</directory>
+                <directory suffix="TestBase.php">./</directory>
+            </exclude>
+        </whitelist>
+    </filter>
+</phpunit>

--- a/src/Client.php
+++ b/src/Client.php
@@ -287,6 +287,10 @@ class Client implements ClientInterface {
         'action' => 'POST',
         'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/schedules',
       ],
+      'update' => [
+        'action' => 'PUT',
+        'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/schedules/{name}',
+      ],
       'delete' => [
         'action' => 'DELETE',
         'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/schedules/{name}',
@@ -1516,6 +1520,13 @@ class Client implements ClientInterface {
   /**
    * {@inheritdoc}
    */
+  public function updateSchedule(ScheduledBackup $schedule) {
+    return $this->createSerializableObject(__METHOD__, $schedule, ['name' => $schedule->getName()]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function deleteSchedule(string $name) {
     return $this->apiCall(__METHOD__, $name);
   }
@@ -1534,6 +1545,8 @@ class Client implements ClientInterface {
    *   The method this has been called from.
    * @param object $object
    *   The object to create.
+   * @param array $params
+   *   Optional params to pass to createRequestUri.
    *
    * @throws \UniversityOfAdelaide\OpenShift\ClientException
    *   A client exception if the creation failed.
@@ -1541,11 +1554,11 @@ class Client implements ClientInterface {
    * @return mixed|bool
    *   Either the object that was created, or false if it failed.
    */
-  private function createSerializableObject($method, $object) {
+  private function createSerializableObject($method, $object, array $params = []) {
     $resourceMethod = $this->getResourceMethod($method);
-    $uri = $this->createRequestUri($resourceMethod['uri']);
-    $schedule = $this->serializer->serialize($object, 'json');
-    if (!$result = $this->request($resourceMethod['action'], $uri, $schedule, [], FALSE)) {
+    $uri = $this->createRequestUri($resourceMethod['uri'], $params);
+    $serialized = $this->serializer->serialize($object, 'json');
+    if (!$result = $this->request($resourceMethod['action'], $uri, $serialized, [], FALSE)) {
       return FALSE;
     }
     return $this->serializer->deserialize($result, get_class($object), 'json');

--- a/src/Client.php
+++ b/src/Client.php
@@ -10,6 +10,7 @@ use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\RestoreList;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Sync;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\SyncList;
 use UniversityOfAdelaide\OpenShift\Objects\Label;
 use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
 
@@ -1537,6 +1538,22 @@ class Client implements ClientInterface {
    */
   public function createSync(Sync $sync) {
     return $this->createSerializableObject(__METHOD__, $sync);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function listSync(Label $label_selector = NULL) {
+    $label = NULL;
+    if ($label_selector) {
+      $label = (string) $label_selector;
+    }
+
+    $result = $this->apiCall(__METHOD__, '', $label, FALSE);
+    if (!$result) {
+      return FALSE;
+    }
+    return $this->serializer->deserialize($result, SyncList::class, 'json');
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -7,6 +7,7 @@ use GuzzleHttp\Exception\RequestException;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\RestoreList;
 use UniversityOfAdelaide\OpenShift\Objects\Label;
 use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
 
@@ -1455,6 +1456,22 @@ class Client implements ClientInterface {
       return FALSE;
     }
     return $this->serializer->deserialize($result, Restore::class, 'json');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function listRestore(Label $label_selector = NULL) {
+    $label = NULL;
+    if ($label_selector) {
+      $label = (string) $label_selector;
+    }
+
+    $result = $this->apiCall(__METHOD__, '', $label, FALSE);
+    if (!$result) {
+      return FALSE;
+    }
+    return $this->serializer->deserialize($result, RestoreList::class, 'json');
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -340,15 +340,15 @@ class Client implements ClientInterface {
     'sync' => [
       'create' => [
         'action' => 'POST',
-        'uri'    => '/apis/environment.backups.shepherd/v1beta1/namespaces/{namespace}/syncs',
+        'uri'    => '/apis/workflow.shepherd/v1beta1/namespaces/{namespace}/syncs',
       ],
       'get'    => [
         'action' => 'GET',
-        'uri'    => '/apis/environment.backups.shepherd/v1beta1/namespaces/{namespace}/syncs/{name}',
+        'uri'    => '/apis/workflow.shepherd/v1beta1/namespaces/{namespace}/syncs/{name}',
       ],
       'list' => [
         'action' => 'GET',
-        'uri'    => '/apis/environment.backups.shepherd/v1beta1/namespaces/{namespace}/syncs',
+        'uri'    => '/apis/workflow.shepherd/v1beta1/namespaces/{namespace}/syncs',
       ],
     ],
   ];

--- a/src/Client.php
+++ b/src/Client.php
@@ -939,7 +939,7 @@ class Client implements ClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function generateDeploymentConfig(string $name, string $image_stream_tag, string $image_name, bool $update_on_image_change = FALSE, array $volumes = [], array $data = [], array $probes = []) {
+  public function generateDeploymentConfig(string $name, string $image_stream_tag, string $image_name, bool $update_on_image_change = FALSE, array $volumes = [], array $data = [], array $probes = [], array $volumes_to_backup = []) {
     $volume_config = $this->setVolumes($volumes);
 
     $securityContext = [];
@@ -975,6 +975,7 @@ class Client implements ClientInterface {
           'metadata' => [
             'annotations' => [
               'openshift.io/container.' . $image_name . '.image.entrypoint' => '["/usr/local/s2i/run"]',
+              Backup::VolumesToBackupAnnotation => $volumes_to_backup ? implode(',', $volumes_to_backup) : '',
             ],
             'labels' => array_key_exists('labels', $data) ? array_merge($data['labels'], ['name' => $name]) : [],
           ],

--- a/src/Client.php
+++ b/src/Client.php
@@ -511,10 +511,12 @@ class Client implements ClientInterface {
 
     // @todo - this should use model.
     $secret = [
-      'api_version' => 'v1',
       'kind' => 'Secret',
       'metadata' => [
         'name' => $name,
+        'labels' => [
+          'app' => $name,
+        ],
       ],
       'type' => 'Opaque',
       'data' => $data,
@@ -545,10 +547,12 @@ class Client implements ClientInterface {
     }
 
     $secret = [
-      'api_version' => 'v1',
       'kind' => 'Secret',
       'metadata' => [
         'name' => $name,
+        'labels' => [
+          'app' => $name,
+        ],
       ],
       'type' => 'Opaque',
       'data' => $data,

--- a/src/Client.php
+++ b/src/Client.php
@@ -8,6 +8,7 @@ use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\RestoreList;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup;
 use UniversityOfAdelaide\OpenShift\Objects\Label;
 use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
 
@@ -274,6 +275,20 @@ class Client implements ClientInterface {
       'update' => [
         'action' => 'PUT',
         'uri'    => '/oapi/v1/namespaces/{namespace}/routes/{name}',
+      ],
+    ],
+    'schedule' => [
+      'get' => [
+        'action' => 'GET',
+        'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/schedules/{name}',
+      ],
+      'create' => [
+        'action' => 'POST',
+        'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/schedules',
+      ],
+      'delete' => [
+        'action' => 'DELETE',
+        'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/schedules/{name}',
       ],
     ],
     'secret' => [
@@ -1476,6 +1491,38 @@ class Client implements ClientInterface {
   }
 
   /**
+   * {@inheritdoc}
+   */
+  public function getSchedule(string $name) {
+    $result = $this->apiCall(__METHOD__, $name, NULL, FALSE);
+    if (!$result) {
+      return FALSE;
+    }
+    return $this->serializer->deserialize($result, ScheduledBackup::class, 'json');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createSchedule(ScheduledBackup $schedule) {
+    $resourceMethod = $this->getResourceMethod(__METHOD__);
+    $uri = $this->createRequestUri($resourceMethod['uri']);
+    $schedule = $this->serializer->serialize($schedule, 'json');
+    $result = $this->request($resourceMethod['action'], $uri, $schedule, [], FALSE);
+    if (!$result) {
+      return FALSE;
+    }
+    return $this->serializer->deserialize($result, ScheduledBackup::class, 'json');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function deleteSchedule(string $name) {
+    return $this->apiCall(__METHOD__, $name);
+  }
+
+  /**
    * Merge annotations into the config, if there are any.
    *
    * Applying a blank annotation causes failures, is why this function exists.
@@ -1632,4 +1679,5 @@ class Client implements ClientInterface {
 
     return $this->request($resourceMethod['action'], $uri, [], $query, $decode_response);
   }
+
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -239,6 +239,24 @@ class Client implements ClientInterface {
         'uri'    => '/api/v1/namespaces/{namespace}/replicationcontrollers/{name}',
       ],
     ],
+    'restore' => [
+      'create' => [
+        'action' => 'POST',
+        'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores',
+      ],
+      'delete' => [
+        'action' => 'DELETE',
+        'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores/{name}',
+      ],
+      'get'    => [
+        'action' => 'GET',
+        'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores/{name}',
+      ],
+      'list' => [
+        'action' => 'GET',
+        'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores',
+      ],
+    ],
     'route' => [
       'create' => [
         'action' => 'POST',

--- a/src/Client.php
+++ b/src/Client.php
@@ -1419,8 +1419,8 @@ class Client implements ClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteBackup(Backup $backup) {
-    return $this->apiCall(__METHOD__, $backup->getName());
+  public function deleteBackup(string $name) {
+    return $this->apiCall(__METHOD__, $name);
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\RequestException;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
+use UniversityOfAdelaide\OpenShift\Objects\Label;
 use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
 
 /**
@@ -1379,7 +1380,7 @@ class Client implements ClientInterface {
    * {@inheritdoc}
    */
   public function getBackup(string $name) {
-    $result = $this->apiCall(__METHOD__, $name, FALSE);
+    $result = $this->apiCall(__METHOD__, $name, NULL, FALSE);
     if (!$result) {
       return FALSE;
     }
@@ -1389,14 +1390,13 @@ class Client implements ClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function listBackup(array $label_selectors = []) {
-    $resourceMethod = $this->getResourceMethod(__METHOD__);
-    $uri = $this->createRequestUri($resourceMethod['uri']);
-    if ($label_selectors) {
-      $query = ['labelSelector' => $label_selectors];
+  public function listBackup(Label $label_selector = NULL) {
+    $label = NULL;
+    if ($label_selector) {
+      $label = (string) $label_selector;
     }
 
-    $result = $this->request($resourceMethod['action'], $uri, [], $query, FALSE);
+    $result = $this->apiCall(__METHOD__, '', $label, FALSE);
     if (!$result) {
       return FALSE;
     }

--- a/src/Client.php
+++ b/src/Client.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\RequestException;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
 use UniversityOfAdelaide\OpenShift\Objects\Label;
 use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
 
@@ -1422,6 +1423,20 @@ class Client implements ClientInterface {
    */
   public function deleteBackup(string $name) {
     return $this->apiCall(__METHOD__, $name);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function createRestore(Restore $restore) {
+    $resourceMethod = $this->getResourceMethod(__METHOD__);
+    $uri = $this->createRequestUri($resourceMethod['uri']);
+    $restoreConfig = $this->serializer->serialize($restore, 'json');
+    $result = $this->request($resourceMethod['action'], $uri, $restoreConfig, [], FALSE);
+    if (!$result) {
+      return FALSE;
+    }
+    return $this->serializer->deserialize($result, Restore::class, 'json');
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -1402,6 +1402,8 @@ class Client implements ClientInterface {
     if (!$result) {
       return FALSE;
     }
+    // @todo fix this, $this->request decodes by default but we want the
+    // serializer to do it for us.
     $data = json_encode($result);
     return $this->serializer->deserialize($data, BackupList::class, 'json');
   }
@@ -1413,7 +1415,14 @@ class Client implements ClientInterface {
     $resourceMethod = $this->getResourceMethod(__METHOD__);
     $uri = $this->createRequestUri($resourceMethod['uri']);
     $backupConfig = $this->serializer->serialize($backup, 'json');
-    return $this->request($resourceMethod['action'], $uri, $backupConfig);
+    $result = $this->request($resourceMethod['action'], $uri, $backupConfig);
+    if (!$result) {
+      return FALSE;
+    }
+    // @todo fix this, $this->request decodes by default but we want the
+    // serializer to do it for us.
+    $data = json_encode($result);
+    return $this->serializer->deserialize($data, Backup::class, 'json');
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -288,7 +288,8 @@ class Client implements ClientInterface {
         'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/schedules',
       ],
       'update' => [
-        'action' => 'PUT',
+        // We use PATCH here since we're using nicely serialized data.
+        'action' => 'PATCH',
         'uri'    => '/apis/ark.heptio.com/v1/namespaces/heptio-ark/schedules/{name}',
       ],
       'delete' => [

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -940,8 +940,8 @@ interface ClientInterface {
   /**
    * Deletes a named backup.
    *
-   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup
-   *   The backup to delete.
+   * @param string $name
+   *   The name backup to delete.
    *
    * @return array
    *   Returns the body response if successful.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -2,6 +2,8 @@
 
 namespace UniversityOfAdelaide\OpenShift;
 
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
+
 /**
  * Interface OpenShiftClientInterface.
  *
@@ -892,5 +894,61 @@ interface ClientInterface {
    *   Throws exception if there is an issue deleting replication controllers.
    */
   public function deleteReplicationControllers($name, $label);
+
+  /**
+   * Retrieves a backup that matches the name.
+   *
+   * @param string $name
+   *   Name of the backup to retrieved.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup|bool
+   *   Returns a Backup if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue retrieving backup.
+   */
+  public function getBackup(string $name);
+
+  /**
+   * Retrieves a list of backups optionally filtered by selectors.
+   *
+   * @param array $label_selectors
+   *   An optional array of label selectors to filter the list by.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList|bool
+   *   Returns a BackupList if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue retrieving the list of backups.
+   */
+  public function listBackup(array $label_selectors = []);
+
+  /**
+   * Creates a new backup.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup
+   *   The backup to create.
+   *
+   * @return array
+   *   Returns the body response if successful.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue creating the backup.
+   */
+  public function createBackup(Backup $backup);
+
+  /**
+   * Deletes a named backup.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup
+   *   The backup to delete.
+   *
+   * @return array
+   *   Returns the body response if successful.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue deleting backup.
+   */
+  public function deleteBackup(string $name);
 
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -606,11 +606,13 @@ interface ClientInterface {
    *   Configuration data for deployment config.
    * @param array $probes
    *   Probe configuration.
+   * @param array $volumes_to_backup
+   *   An array of volume names to backup.
    *
    * @return array
    *   Returns the body response if successful.
    */
-  public function generateDeploymentConfig(string $name, string $image_stream_tag, string $image_name, bool $update_on_image_change, array $volumes, array $data, array $probes);
+  public function generateDeploymentConfig(string $name, string $image_stream_tag, string $image_name, bool $update_on_image_change, array $volumes, array $data, array $probes, array $volumes_to_backup = []);
 
   /**
    * Updates and existing deployment config.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -1016,6 +1016,20 @@ interface ClientInterface {
   public function createSchedule(ScheduledBackup $schedule);
 
   /**
+   * Updates an existing schedule.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup $schedule
+   *   The schedule to update.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup|bool
+   *   Returns a ScheduledBackup if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue creating the ScheduledBackup.
+   */
+  public function updateSchedule(ScheduledBackup $schedule);
+
+  /**
    * Deletes a named schedule.
    *
    * @param string $name

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -3,6 +3,7 @@
 namespace UniversityOfAdelaide\OpenShift;
 
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
 use UniversityOfAdelaide\OpenShift\Objects\Label;
 
 /**
@@ -953,5 +954,19 @@ interface ClientInterface {
    *   Throws exception if there is an issue deleting backup.
    */
   public function deleteBackup(string $name);
+
+  /**
+   * Creates a new restore.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore $restore
+   *   The restore to create.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore|bool
+   *   Returns a Restore if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue creating the restore.
+   */
+  public function createRestore(Restore $restore);
 
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -3,6 +3,7 @@
 namespace UniversityOfAdelaide\OpenShift;
 
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
+use UniversityOfAdelaide\OpenShift\Objects\Label;
 
 /**
  * Interface OpenShiftClientInterface.
@@ -914,8 +915,8 @@ interface ClientInterface {
   /**
    * Retrieves a list of backups optionally filtered by selectors.
    *
-   * @param array $label_selectors
-   *   An optional array of label selectors to filter the list by.
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Label $label_selector
+   *   An optional label selector to apply to the query.
    *
    * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList|bool
    *   Returns a BackupList if successful, false if it does not exist.
@@ -923,7 +924,7 @@ interface ClientInterface {
    * @throws ClientException
    *   Throws exception if there is an issue retrieving the list of backups.
    */
-  public function listBackup(array $label_selectors = []);
+  public function listBackup(Label $label_selector = NULL);
 
   /**
    * Creates a new backup.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -5,6 +5,7 @@ namespace UniversityOfAdelaide\OpenShift;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Sync;
 use UniversityOfAdelaide\OpenShift\Objects\Label;
 
 /**
@@ -1027,5 +1028,19 @@ interface ClientInterface {
    *   Throws exception if there is an issue deleting schedule.
    */
   public function deleteSchedule(string $name);
+
+  /**
+   * Creates a new sync.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync $sync
+   *   The sync to create.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync|bool
+   *   Returns a Sync if successful, false if it failed.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue creating the sync.
+   */
+  public function createSync(Sync $sync);
 
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -929,8 +929,8 @@ interface ClientInterface {
    * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup
    *   The backup to create.
    *
-   * @return array
-   *   Returns the body response if successful.
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup|bool
+   *   Returns a Backup if successful, false if it does not exist.
    *
    * @throws ClientException
    *   Throws exception if there is an issue creating the backup.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -4,6 +4,7 @@ namespace UniversityOfAdelaide\OpenShift;
 
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup;
 use UniversityOfAdelaide\OpenShift\Objects\Label;
 
 /**
@@ -984,5 +985,47 @@ interface ClientInterface {
    *   Throws exception if there is an issue retrieving the list of backups.
    */
   public function listRestore(Label $label_selector = NULL);
+
+  /**
+   * Retrieves a schedule that matches the name.
+   *
+   * @param string $name
+   *   Name of the schedule to retrieved.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup|bool
+   *   Returns a ScheduledBackup if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue retrieving schedule.
+   */
+  public function getSchedule(string $name);
+
+  /**
+   * Creates a new schedule.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup $schedule
+   *   The schedule to create.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup|bool
+   *   Returns a ScheduledBackup if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue creating the ScheduledBackup.
+   */
+  public function createSchedule(ScheduledBackup $schedule);
+
+  /**
+   * Deletes a named schedule.
+   *
+   * @param string $name
+   *   The name schedule to delete.
+   *
+   * @return array
+   *   Returns the body response if successful.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue deleting schedule.
+   */
+  public function deleteSchedule(string $name);
 
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -1057,4 +1057,18 @@ interface ClientInterface {
    */
   public function createSync(Sync $sync);
 
+  /**
+   * Retrieves a list of syncs optionally filtered by selectors.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Label $label_selector
+   *   An optional label selector to apply to the query.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncList|bool
+   *   Returns a SyncList if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue retrieving the list of backups.
+   */
+  public function listSync(Label $label_selector = NULL);
+
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -32,10 +32,12 @@ interface ClientInterface {
    *   HTTP VERB.
    * @param string $uri
    *   Path the endpoint.
-   * @param array $body
-   *   Request body to be converted to JSON.
+   * @param mixed $body
+   *   Request body to be converted to JSON. Can be passed in as JSON.
    * @param array $query
    *   Query params.
+   * @param bool $decode_response
+   *   Whether to decode the response or not.
    *
    * @return array|bool
    *   Returns json_decoded body contents or FALSE.
@@ -43,7 +45,7 @@ interface ClientInterface {
    * @throws ClientException
    *   Throws exception if there is an issue performing request.
    */
-  public function request(string $method, string $uri, array $body = [], array $query = []);
+  public function request(string $method, string $uri, $body = NULL, array $query = [], $decode_response = TRUE);
 
   /**
    * Retrieves a secret that matches the name/tag.

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -969,4 +969,18 @@ interface ClientInterface {
    */
   public function createRestore(Restore $restore);
 
+  /**
+   * Retrieves a list of restores optionally filtered by selectors.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Label $label_selector
+   *   An optional label selector to apply to the query.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\RestoreList|bool
+   *   Returns a RestoreList if successful, false if it does not exist.
+   *
+   * @throws ClientException
+   *   Throws exception if there is an issue retrieving the list of backups.
+   */
+  public function listRestore(Label $label_selector = NULL);
+
 }

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -63,7 +63,7 @@ class Backup {
    *
    * @var string
    */
-  protected $completionTimestamp;
+  protected $completionTimestamp = '';
 
   /**
    * The time the backup expires.
@@ -133,17 +133,30 @@ class Backup {
   /**
    * Set a single label.
    *
-   * @param string $labelName
-   *   The name of the label.
-   * @param string $labelValue
+   * @param string $key
+   *   The key of the label.
+   * @param string $value
    *   The value of the label.
    *
    * @return $this
    *   The calling class.
    */
-  public function setLabel(string $labelName, string $labelValue): Backup {
-    $this->labels[$labelName] = $labelValue;
+  public function setLabel(string $key, string $value): Backup {
+    $this->labels[$key] = $value;
     return $this;
+  }
+
+  /**
+   * Get a single label.
+   *
+   * @param string $key
+   *   The key of the label.
+   *
+   * @return string|bool
+   *   The label value, or FALSE if it doesn't exist.
+   */
+  public function getLabel(string $key): string {
+    return isset($this->getLabels()[$key]) ? $this->getLabels()[$key] : FALSE;
   }
 
   /**
@@ -274,6 +287,16 @@ class Backup {
    */
   public function getCompletionTimestamp(): string {
     return $this->completionTimestamp;
+  }
+
+  /**
+   * Check if the backup is completed.
+   *
+   * @return bool
+   *   Whether the backup has completed.
+   */
+  public function isCompleted(): bool {
+    return $this->getPhase() === Phase::COMPLETED;
   }
 
   /**

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -66,7 +66,7 @@ class Backup extends BackupObjectBase {
    *
    * @var string
    */
-  protected $expires;
+  protected $expires = '';
 
   /**
    * Factory method for creating a new Backup.

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -69,16 +69,6 @@ class Backup extends BackupObjectBase {
   protected $expires = '';
 
   /**
-   * Factory method for creating a new Backup.
-   *
-   * @return self
-   *   Returns static object.
-   */
-  public static function create() {
-    return new static();
-  }
-
-  /**
    * Get a single annotation.
    *
    * @param string $key

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -1,0 +1,299 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines a value object representing a Backup.
+ */
+class Backup {
+
+  /**
+   * The name of the backup.
+   *
+   * @var string
+   */
+  protected $name;
+
+  /**
+   * The array of labels to apply to this backup.
+   *
+   * @var array
+   */
+  protected $labels = [
+    'ark.heptio.com/storage-location' => 'default',
+  ];
+
+  /**
+   * An array of hooks to run during this backup.
+   *
+   * @var \Drupal\shp_backup\Backups\Hook[]
+   */
+  protected $hooks = [];
+
+  /**
+   * The TTL for this backup.
+   *
+   * @var string
+   */
+  protected $ttl = '720h0m0s';
+
+  /**
+   * An array of labels that must be matched to be included in the backup.
+   *
+   * @var array
+   */
+  protected $matchLabels = [];
+
+  /**
+   * The phase the backup is in.
+   *
+   * @var string
+   */
+  protected $phase;
+
+  /**
+   * The time the backup was started.
+   *
+   * @var string
+   */
+  protected $startTimestamp;
+
+  /**
+   * The time the backup completed.
+   *
+   * @var string
+   */
+  protected $completionTimestamp;
+
+  /**
+   * The time the backup expires.
+   *
+   * @var string
+   */
+  protected $expires;
+
+  /**
+   * Factory method for creating a new Backup.
+   *
+   * @return self
+   *   Returns static object.
+   */
+  public static function create() {
+    return new static();
+  }
+
+  /**
+   * Gets the value of name.
+   *
+   * @return string
+   *   Value of name.
+   */
+  public function getName(): string {
+    return $this->name;
+  }
+
+  /**
+   * Sets the name.
+   *
+   * @param string $name
+   *   The name of the backup.
+   *
+   *  @return $this
+   *   The calling class.
+   */
+  public function setName(string $name): Backup {
+    $this->name = $name;
+    return $this;
+  }
+
+  /**
+   * Gets the value of labels.
+   *
+   * @return array
+   *  Value of labels.
+   */
+  public function getLabels(): array {
+    return $this->labels;
+  }
+
+  /**
+   * @param array $labels
+   *   An array of labels.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setLabels(array $labels): Backup {
+    $this->labels = $labels;
+    return $this;
+  }
+
+  /**
+   * Gets the value of hooks.
+   *
+   * @return \Drupal\shp_backup\Backups\Hook[]
+   *  Value of hooks.
+   */
+  public function getHooks(): array {
+    return $this->hooks;
+  }
+
+  /**
+   * Sets the value for hooks.
+   *
+   * @param \Drupal\shp_backup\Backups\Hook[] $hooks
+   *   An array of hook objects.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setHooks(array $hooks): Backup {
+    $this->hooks = $hooks;
+    return $this;
+  }
+
+  /**
+   * Gets the value of ttl.
+   *
+   * @return string
+   *  Value of ttl.
+   */
+  public function getTtl(): string {
+    return $this->ttl;
+  }
+
+  /**
+   * Sets the TTL.
+   *
+   * @param string $ttl
+   *   The ttl.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setTtl(string $ttl): Backup {
+    $this->ttl = $ttl;
+    return $this;
+  }
+
+  /**
+   * Gets the value of matchLabels.
+   *
+   * @return array
+   *  Value of matchLabels.
+   */
+  public function getMatchLabels(): array {
+    return $this->matchLabels;
+  }
+
+  /**
+   * Sets the match labels.
+   *
+   * @param array $matchLabels
+   *   An array of labels.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setMatchLabels(array $matchLabels): Backup {
+    $this->matchLabels = $matchLabels;
+    return $this;
+  }
+
+  /**
+   * Gets the value of phase.
+   *
+   * @return string
+   *  Value of phase.
+   */
+  public function getPhase(): string {
+    return $this->phase;
+  }
+
+  /**
+   * Sets the value of phase.
+   *
+   * @param string $phase
+   *  The value for phase.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setPhase(string $phase): Backup {
+    $this->phase = $phase;
+    return $this;
+  }
+
+  /**
+   * Gets the value of startTimestamp.
+   *
+   * @return string
+   *  Value of startTimestamp.
+   */
+  public function getStartTimestamp(): string {
+    return $this->startTimestamp;
+  }
+
+  /**
+   * Sets the value of startTimestamp.
+   *
+   * @param string $startTimestamp
+   *  The value for startTimestamp.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setStartTimestamp(string $startTimestamp): Backup {
+    $this->startTimestamp = $startTimestamp;
+    return $this;
+  }
+
+  /**
+   * Gets the value of completionTimestamp.
+   *
+   * @return string
+   *  Value of completionTimestamp.
+   */
+  public function getCompletionTimestamp(): string {
+    return $this->completionTimestamp;
+  }
+
+  /**
+   * Sets the value of completionTimestamp.
+   *
+   * @param string $completionTimestamp
+   *  The value for completionTimestamp.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setCompletionTimestamp(string $completionTimestamp): Backup {
+    $this->completionTimestamp = $completionTimestamp;
+    return $this;
+  }
+
+  /**
+   * Gets the value of expires.
+   *
+   * @return string
+   *  Value of expires.
+   */
+  public function getExpires(): string {
+    return $this->expires;
+  }
+
+  /**
+   * Sets the value of expires.
+   *
+   * @param string $expires
+   *  The value for expires.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setExpires(string $expires): Backup {
+    $this->expires = $expires;
+    return $this;
+  }
+
+}

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -8,6 +8,11 @@ namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
 class Backup extends BackupObjectBase {
 
   /**
+   * The name of the annotation on pods to signal ark to backup its volumes.
+   */
+  const VolumesToBackupAnnotation = 'backup.ark.heptio.com/backup-volumes';
+
+  /**
    * The array of labels to apply to this backup.
    *
    * @var array

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -13,9 +13,14 @@ class Backup extends BackupObjectBase {
   const VolumesToBackupAnnotation = 'backup.ark.heptio.com/backup-volumes';
 
   /**
-   * The array of labels to apply to this backup.
+   * An array of annotations to apply to this backup.
    *
    * @var array
+   */
+  protected $annotations = [];
+
+  /**
+   * {@inheritdoc}
    */
   protected $labels = [
     'ark.heptio.com/storage-location' => 'default',
@@ -74,26 +79,66 @@ class Backup extends BackupObjectBase {
   }
 
   /**
-   * Gets the value of hooks.
+   * Get a single annotation.
    *
-   * @return \Drupal\shp_backup\Backups\Hook[]
-   *  Value of hooks.
+   * @param string $key
+   *   The key for the annotation.
+   *
+   * @return string|bool
+   *   The annotation value or FALSE.
    */
-  public function getHooks(): array {
-    return $this->hooks;
+  public function getAnnotation(string $key): string {
+    return isset($this->getAnnotations()[$key]) ? $this->getAnnotations()[$key] : FALSE;
+
   }
 
   /**
-   * Sets the value for hooks.
+   * Gets the value of annotations.
    *
-   * @param \Drupal\shp_backup\Backups\Hook[] $hooks
-   *   An array of hook objects.
-   *
-   * @return $this
-   *  The calling class.
+   * @return array
+   *   Value of annotations.
    */
-  public function setHooks(array $hooks): Backup {
-    $this->hooks = $hooks;
+  public function getAnnotations(): array {
+    return $this->annotations;
+  }
+
+  /**
+   * Check if this backup has any annotations.
+   *
+   * @return bool
+   *   Whether this backup has annotations.
+   */
+  public function hasAnnotations(): bool {
+    return !empty($this->getAnnotations());
+  }
+
+  /**
+   * Set a single annotation.
+   *
+   * @param string $key
+   *   The key for the annotation.
+   * @param string $value
+   *   The value for the annotation.
+   *
+   * @return Backup
+   *   The calling class.
+   */
+  public function setAnnotation(string $key, string $value): Backup {
+    $this->annotations[$key] = $value;
+    return $this;
+  }
+
+  /**
+   * Sets the value of annotations.
+   *
+   * @param array $annotations
+   *   The value for annotations.
+   *
+   * @return Backup
+   *   The calling class.
+   */
+  public function setAnnotations(array $annotations): Backup {
+    $this->annotations = $annotations;
     return $this;
   }
 
@@ -101,7 +146,7 @@ class Backup extends BackupObjectBase {
    * Gets the value of ttl.
    *
    * @return string
-   *  Value of ttl.
+   *   Value of ttl.
    */
   public function getTtl(): string {
     return $this->ttl;
@@ -114,7 +159,7 @@ class Backup extends BackupObjectBase {
    *   The ttl.
    *
    * @return $this
-   *  The calling class.
+   *   The calling class.
    */
   public function setTtl(string $ttl): Backup {
     $this->ttl = $ttl;
@@ -125,7 +170,7 @@ class Backup extends BackupObjectBase {
    * Gets the value of matchLabels.
    *
    * @return array
-   *  Value of matchLabels.
+   *   Value of matchLabels.
    */
   public function getMatchLabels(): array {
     return $this->matchLabels;
@@ -138,7 +183,7 @@ class Backup extends BackupObjectBase {
    *   An array of labels.
    *
    * @return $this
-   *  The calling class.
+   *   The calling class.
    */
   public function setMatchLabels(array $matchLabels): Backup {
     $this->matchLabels = $matchLabels;
@@ -149,7 +194,7 @@ class Backup extends BackupObjectBase {
    * Gets the value of startTimestamp.
    *
    * @return string
-   *  Value of startTimestamp.
+   *   Value of startTimestamp.
    */
   public function getStartTimestamp(): string {
     return $this->startTimestamp;
@@ -159,10 +204,10 @@ class Backup extends BackupObjectBase {
    * Sets the value of startTimestamp.
    *
    * @param string $startTimestamp
-   *  The value for startTimestamp.
+   *   The value for startTimestamp.
    *
    * @return $this
-   *  The calling class.
+   *   The calling class.
    */
   public function setStartTimestamp(string $startTimestamp): Backup {
     $this->startTimestamp = $startTimestamp;
@@ -173,7 +218,7 @@ class Backup extends BackupObjectBase {
    * Gets the value of completionTimestamp.
    *
    * @return string
-   *  Value of completionTimestamp.
+   *   Value of completionTimestamp.
    */
   public function getCompletionTimestamp(): string {
     return $this->completionTimestamp;
@@ -183,10 +228,10 @@ class Backup extends BackupObjectBase {
    * Sets the value of completionTimestamp.
    *
    * @param string $completionTimestamp
-   *  The value for completionTimestamp.
+   *   The value for completionTimestamp.
    *
    * @return $this
-   *  The calling class.
+   *   The calling class.
    */
   public function setCompletionTimestamp(string $completionTimestamp): Backup {
     $this->completionTimestamp = $completionTimestamp;
@@ -197,7 +242,7 @@ class Backup extends BackupObjectBase {
    * Gets the value of expires.
    *
    * @return string
-   *  Value of expires.
+   *   Value of expires.
    */
   public function getExpires(): string {
     return $this->expires;
@@ -207,10 +252,10 @@ class Backup extends BackupObjectBase {
    * Sets the value of expires.
    *
    * @param string $expires
-   *  The value for expires.
+   *   The value for expires.
    *
    * @return $this
-   *  The calling class.
+   *   The calling class.
    */
   public function setExpires(string $expires): Backup {
     $this->expires = $expires;

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -56,7 +56,7 @@ class Backup {
    *
    * @var string
    */
-  protected $startTimestamp;
+  protected $startTimestamp = '';
 
   /**
    * The time the backup completed.

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -5,14 +5,7 @@ namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
 /**
  * Defines a value object representing a Backup.
  */
-class Backup {
-
-  /**
-   * The name of the backup.
-   *
-   * @var string
-   */
-  protected $name;
+class Backup extends BackupObjectBase {
 
   /**
    * The array of labels to apply to this backup.
@@ -45,13 +38,6 @@ class Backup {
   protected $matchLabels = [];
 
   /**
-   * The phase the backup is in.
-   *
-   * @var string
-   */
-  protected $phase;
-
-  /**
    * The time the backup was started.
    *
    * @var string
@@ -80,83 +66,6 @@ class Backup {
    */
   public static function create() {
     return new static();
-  }
-
-  /**
-   * Gets the value of name.
-   *
-   * @return string
-   *   Value of name.
-   */
-  public function getName(): string {
-    return $this->name;
-  }
-
-  /**
-   * Sets the name.
-   *
-   * @param string $name
-   *   The name of the backup.
-   *
-   *  @return $this
-   *   The calling class.
-   */
-  public function setName(string $name): Backup {
-    $this->name = $name;
-    return $this;
-  }
-
-  /**
-   * Gets the value of labels.
-   *
-   * @return array
-   *  Value of labels.
-   */
-  public function getLabels(): array {
-    return $this->labels;
-  }
-
-  /**
-   * Sets the array of labels.
-   *
-   * @param array $labels
-   *   An array of labels.
-   *
-   * @return $this
-   *   The calling class.
-   */
-  public function setLabels(array $labels): Backup {
-    $this->labels = $labels;
-    return $this;
-  }
-
-  /**
-   * Set a single label.
-   *
-   * @param string $key
-   *   The key of the label.
-   * @param string $value
-   *   The value of the label.
-   *
-   * @return $this
-   *   The calling class.
-   */
-  public function setLabel(string $key, string $value): Backup {
-    $this->labels[$key] = $value;
-    return $this;
-  }
-
-  /**
-   * Get a single label.
-   *
-   * @param string $key
-   *   The key of the label.
-   *
-   * @return string|bool
-   *   The label value, or FALSE if it doesn't exist.
-   */
-  public function getLabel(string $key): string {
-    return isset($this->getLabels()[$key]) ? $this->getLabels()[$key] : FALSE;
   }
 
   /**
@@ -232,30 +141,6 @@ class Backup {
   }
 
   /**
-   * Gets the value of phase.
-   *
-   * @return string
-   *  Value of phase.
-   */
-  public function getPhase(): string {
-    return $this->phase;
-  }
-
-  /**
-   * Sets the value of phase.
-   *
-   * @param string $phase
-   *  The value for phase.
-   *
-   * @return $this
-   *  The calling class.
-   */
-  public function setPhase(string $phase): Backup {
-    $this->phase = $phase;
-    return $this;
-  }
-
-  /**
    * Gets the value of startTimestamp.
    *
    * @return string
@@ -287,16 +172,6 @@ class Backup {
    */
   public function getCompletionTimestamp(): string {
     return $this->completionTimestamp;
-  }
-
-  /**
-   * Check if the backup is completed.
-   *
-   * @return bool
-   *   Whether the backup has completed.
-   */
-  public function isCompleted(): bool {
-    return $this->getPhase() === Phase::COMPLETED;
   }
 
   /**

--- a/src/Objects/Backups/Backup.php
+++ b/src/Objects/Backups/Backup.php
@@ -117,6 +117,8 @@ class Backup {
   }
 
   /**
+   * Sets the array of labels.
+   *
    * @param array $labels
    *   An array of labels.
    *
@@ -125,6 +127,22 @@ class Backup {
    */
   public function setLabels(array $labels): Backup {
     $this->labels = $labels;
+    return $this;
+  }
+
+  /**
+   * Set a single label.
+   *
+   * @param string $labelName
+   *   The name of the label.
+   * @param string $labelValue
+   *   The value of the label.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setLabel(string $labelName, string $labelValue): Backup {
+    $this->labels[$labelName] = $labelValue;
     return $this;
   }
 

--- a/src/Objects/Backups/BackupList.php
+++ b/src/Objects/Backups/BackupList.php
@@ -5,7 +5,7 @@ namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
 /**
  * Defines a value object representing a BackupList.
  */
-class BackupList {
+class BackupList extends ObjectListBase {
 
   /**
    * The list of backups.
@@ -32,6 +32,19 @@ class BackupList {
    */
   public function getBackups(): array {
     return $this->backups;
+  }
+
+  /**
+   * Gets a list of backups ordered by created time.
+   *
+   * @param string $operator
+   *   Which way to order the list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
+   *   The list of sorted backups.
+   */
+  public function getBackupsByCreatedTime($operator = 'DESC'): array {
+    return $this->sortObjectsByCreationTime($this->getBackups(), $operator);
   }
 
   /**

--- a/src/Objects/Backups/BackupList.php
+++ b/src/Objects/Backups/BackupList.php
@@ -12,7 +12,7 @@ class BackupList {
    *
    * @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
    */
-  protected $backups;
+  protected $backups = [];
 
   /**
    * Factory method for creating a new BackupList.

--- a/src/Objects/Backups/BackupList.php
+++ b/src/Objects/Backups/BackupList.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines a value object representing a BackupList.
+ */
+class BackupList {
+
+  /**
+   * The list of backups.
+   *
+   * @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
+   */
+  protected $backups;
+
+  /**
+   * Factory method for creating a new BackupList.
+   *
+   * @return self
+   *   Returns static object.
+   */
+  public static function create() {
+    return new static();
+  }
+
+  /**
+   * Gets the backup list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
+   *  The list of backups.
+   */
+  public function getBackups(): array {
+    return $this->backups;
+  }
+
+  /**
+   * Adds a backup to the list.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup $backup
+   *   The backup to add to the list.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function addBackup(Backup $backup): BackupList {
+    $this->backups[] = $backup;
+    return $this;
+  }
+
+  /**
+   * Gets the number of backups.
+   *
+   * @return int
+   *   The number of backups in this list.
+   */
+  public function getBackupCount(): int {
+    return count($this->getBackups());
+  }
+
+  /**
+   * Checks there are backups in this list.
+   *
+   * @return bool
+   *   TRUE if there are any backups.
+   */
+  public function hasBackups():bool {
+    return (bool) $this->getBackupCount();
+  }
+
+}

--- a/src/Objects/Backups/BackupList.php
+++ b/src/Objects/Backups/BackupList.php
@@ -28,22 +28,66 @@ class BackupList {
    * Gets the backup list.
    *
    * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
-   *  The list of backups.
+   *   The list of backups.
    */
   public function getBackups(): array {
     return $this->backups;
   }
 
   /**
+   * Sorts an array of backups by start time.
+   *
+   * @param array $backups
+   *   The array of backups.
+   * @param string $operator
+   *   The sort operator.
+   *
+   * @return array
+   *   The sorted array.
+   */
+  protected function sortBackupsByStartTime(array $backups, string $operator) {
+    usort($backups, function (Backup $a, Backup $b) use ($operator) {
+      return $operator === 'DESC' ? $a->getStartTimestamp() < $b->getStartTimestamp() : $a->getStartTimestamp() > $b->getStartTimestamp();
+    });
+    return $backups;
+  }
+
+  /**
+   * Gets a list of backups ordered by start time.
+   *
+   * @param string $operator
+   *   Which way to order the list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
+   *   The list of backups.
+   */
+  public function getBackupsByStartTime($operator = 'DESC'): array {
+    return $this->sortBackupsByStartTime($this->getBackups(), $operator);
+  }
+
+  /**
    * Gets the backup list.
    *
    * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
-   *  The list of backups.
+   *   The list of backups.
    */
   public function getCompletedBackups(): array {
-    return array_filter($this->backups, function (Backup $backup) {
-      return $backup->getPhase() === Phase::COMPLETED;
+    return array_filter($this->getBackups(), function (Backup $backup) {
+      return $backup->isCompleted();
     });
+  }
+
+  /**
+   * Gets a list of completed backups ordered by start time.
+   *
+   * @param string $operator
+   *   Which way to order the list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
+   *   The list of backups.
+   */
+  public function getCompletedBackupsByStartTime($operator = 'DESC'): array {
+    return $this->sortBackupsByStartTime($this->getCompletedBackups(), $operator);
   }
 
   /**

--- a/src/Objects/Backups/BackupList.php
+++ b/src/Objects/Backups/BackupList.php
@@ -35,6 +35,18 @@ class BackupList {
   }
 
   /**
+   * Gets the backup list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
+   *  The list of backups.
+   */
+  public function getCompletedBackups(): array {
+    return array_filter($this->backups, function (Backup $backup) {
+      return $backup->getPhase() === Phase::COMPLETED;
+    });
+  }
+
+  /**
    * Adds a backup to the list.
    *
    * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup $backup

--- a/src/Objects/Backups/BackupObjectBase.php
+++ b/src/Objects/Backups/BackupObjectBase.php
@@ -2,26 +2,10 @@
 
 namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
 
-use UniversityOfAdelaide\OpenShift\Objects\Label;
-
 /**
  * A base class for backup and restore objects.
  */
-abstract class BackupObjectBase {
-
-  /**
-   * The name of the object.
-   *
-   * @var string
-   */
-  protected $name;
-
-  /**
-   * An array of labels.
-   *
-   * @var array
-   */
-  protected $labels = [];
+abstract class BackupObjectBase extends ObjectBase {
 
   /**
    * The phase the object is in.
@@ -29,81 +13,6 @@ abstract class BackupObjectBase {
    * @var string
    */
   protected $phase = '';
-
-  /**
-   * Gets the value of name.
-   *
-   * @return string
-   *   Value of name.
-   */
-  public function getName(): string {
-    return $this->name;
-  }
-
-  /**
-   * Sets the name.
-   *
-   * @param string $name
-   *   The name of the object.
-   *
-   * @return $this
-   *   The calling class.
-   */
-  public function setName(string $name) {
-    $this->name = $name;
-    return $this;
-  }
-
-  /**
-   * Gets the value of labels.
-   *
-   * @return array
-   *   Value of labels.
-   */
-  public function getLabels(): array {
-    return $this->labels;
-  }
-
-  /**
-   * Sets the array of labels.
-   *
-   * @param array $labels
-   *   An array of labels.
-   *
-   * @return $this
-   *   The calling class.
-   */
-  public function setLabels(array $labels) {
-    $this->labels = $labels;
-    return $this;
-  }
-
-  /**
-   * Set a single label.
-   *
-   * @param \UniversityOfAdelaide\OpenShift\Objects\Label $label
-   *   The label object.
-   *
-   * @return $this
-   *   The calling class.
-   */
-  public function setLabel(Label $label) {
-    $this->labels[$label->getKey()] = $label->getValue();
-    return $this;
-  }
-
-  /**
-   * Get a single label.
-   *
-   * @param string $key
-   *   The key of the label.
-   *
-   * @return string|bool
-   *   The label value, or FALSE if it doesn't exist.
-   */
-  public function getLabel(string $key): string {
-    return isset($this->getLabels()[$key]) ? $this->getLabels()[$key] : FALSE;
-  }
 
   /**
    * Gets the value of phase.

--- a/src/Objects/Backups/BackupObjectBase.php
+++ b/src/Objects/Backups/BackupObjectBase.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * A base class for backup and restore objects.
+ */
+abstract class BackupObjectBase {
+
+  /**
+   * The name of the restore.
+   *
+   * @var string
+   */
+  protected $name;
+
+  /**
+   * An array of labels.
+   *
+   * @var array
+   */
+  protected $labels = [];
+
+  /**
+   * The phase the backup is in.
+   *
+   * @var string
+   */
+  protected $phase;
+
+  /**
+   * Gets the value of name.
+   *
+   * @return string
+   *   Value of name.
+   */
+  public function getName(): string {
+    return $this->name;
+  }
+
+  /**
+   * Sets the name.
+   *
+   * @param string $name
+   *   The name of the backup.
+   *
+   *  @return $this
+   *   The calling class.
+   */
+  public function setName(string $name) {
+    $this->name = $name;
+    return $this;
+  }
+
+  /**
+   * Gets the value of labels.
+   *
+   * @return array
+   *  Value of labels.
+   */
+  public function getLabels(): array {
+    return $this->labels;
+  }
+
+  /**
+   * Sets the array of labels.
+   *
+   * @param array $labels
+   *   An array of labels.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setLabels(array $labels) {
+    $this->labels = $labels;
+    return $this;
+  }
+
+  /**
+   * Set a single label.
+   *
+   * @param string $key
+   *   The key of the label.
+   * @param string $value
+   *   The value of the label.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setLabel(string $key, string $value) {
+    $this->labels[$key] = $value;
+    return $this;
+  }
+
+  /**
+   * Get a single label.
+   *
+   * @param string $key
+   *   The key of the label.
+   *
+   * @return string|bool
+   *   The label value, or FALSE if it doesn't exist.
+   */
+  public function getLabel(string $key): string {
+    return isset($this->getLabels()[$key]) ? $this->getLabels()[$key] : FALSE;
+  }
+
+  /**
+   * Gets the value of phase.
+   *
+   * @return string
+   *  Value of phase.
+   */
+  public function getPhase(): string {
+    return $this->phase;
+  }
+
+  /**
+   * Sets the value of phase.
+   *
+   * @param string $phase
+   *  The value for phase.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setPhase(string $phase) {
+    $this->phase = $phase;
+    return $this;
+  }
+
+  /**
+   * Check if the backup is completed.
+   *
+   * @return bool
+   *   Whether the backup has completed.
+   */
+  public function isCompleted(): bool {
+    return $this->getPhase() === Phase::COMPLETED;
+  }
+
+}

--- a/src/Objects/Backups/BackupObjectBase.php
+++ b/src/Objects/Backups/BackupObjectBase.php
@@ -2,6 +2,8 @@
 
 namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
 
+use UniversityOfAdelaide\OpenShift\Objects\Label;
+
 /**
  * A base class for backup and restore objects.
  */
@@ -79,16 +81,14 @@ abstract class BackupObjectBase {
   /**
    * Set a single label.
    *
-   * @param string $key
-   *   The key of the label.
-   * @param string $value
-   *   The value of the label.
+   * @param Label $label
+   *   The label object.
    *
    * @return $this
    *   The calling class.
    */
-  public function setLabel(string $key, string $value) {
-    $this->labels[$key] = $value;
+  public function setLabel(Label $label) {
+    $this->labels[$label->getKey()] = $label->getValue();
     return $this;
   }
 

--- a/src/Objects/Backups/BackupObjectBase.php
+++ b/src/Objects/Backups/BackupObjectBase.php
@@ -28,7 +28,7 @@ abstract class BackupObjectBase {
    *
    * @var string
    */
-  protected $phase;
+  protected $phase = '';
 
   /**
    * Gets the value of name.
@@ -46,7 +46,7 @@ abstract class BackupObjectBase {
    * @param string $name
    *   The name of the object.
    *
-   *  @return $this
+   * @return $this
    *   The calling class.
    */
   public function setName(string $name) {
@@ -58,7 +58,7 @@ abstract class BackupObjectBase {
    * Gets the value of labels.
    *
    * @return array
-   *  Value of labels.
+   *   Value of labels.
    */
   public function getLabels(): array {
     return $this->labels;
@@ -81,7 +81,7 @@ abstract class BackupObjectBase {
   /**
    * Set a single label.
    *
-   * @param Label $label
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Label $label
    *   The label object.
    *
    * @return $this
@@ -109,7 +109,7 @@ abstract class BackupObjectBase {
    * Gets the value of phase.
    *
    * @return string
-   *  Value of phase.
+   *   Value of phase.
    */
   public function getPhase(): string {
     return $this->phase;
@@ -119,10 +119,10 @@ abstract class BackupObjectBase {
    * Sets the value of phase.
    *
    * @param string $phase
-   *  The value for phase.
+   *   The value for phase.
    *
    * @return $this
-   *  The calling class.
+   *   The calling class.
    */
   public function setPhase(string $phase) {
     $this->phase = $phase;

--- a/src/Objects/Backups/BackupObjectBase.php
+++ b/src/Objects/Backups/BackupObjectBase.php
@@ -8,7 +8,7 @@ namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
 abstract class BackupObjectBase {
 
   /**
-   * The name of the restore.
+   * The name of the object.
    *
    * @var string
    */
@@ -22,7 +22,7 @@ abstract class BackupObjectBase {
   protected $labels = [];
 
   /**
-   * The phase the backup is in.
+   * The phase the object is in.
    *
    * @var string
    */
@@ -42,7 +42,7 @@ abstract class BackupObjectBase {
    * Sets the name.
    *
    * @param string $name
-   *   The name of the backup.
+   *   The name of the object.
    *
    *  @return $this
    *   The calling class.
@@ -130,10 +130,10 @@ abstract class BackupObjectBase {
   }
 
   /**
-   * Check if the backup is completed.
+   * Check if the object phase is completed.
    *
    * @return bool
-   *   Whether the backup has completed.
+   *   Whether the object phase is completed.
    */
   public function isCompleted(): bool {
     return $this->getPhase() === Phase::COMPLETED;

--- a/src/Objects/Backups/Hook.php
+++ b/src/Objects/Backups/Hook.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines a value object for a backup Hook.
+ */
+class Hook {
+
+  /**
+   * Factory method for creating a new Hook.
+   *
+   * @return self
+   *   Returns static object.
+   */
+  public static function create() {
+    return new static();
+  }
+
+}

--- a/src/Objects/Backups/ObjectBase.php
+++ b/src/Objects/Backups/ObjectBase.php
@@ -24,6 +24,13 @@ abstract class ObjectBase {
   protected $labels = [];
 
   /**
+   * The time the object was created.
+   *
+   * @var string
+   */
+  protected $creationTimestamp;
+
+  /**
    * Factory method for creating a new object.
    *
    * @return self
@@ -106,6 +113,30 @@ abstract class ObjectBase {
    */
   public function getLabel(string $key): string {
     return isset($this->getLabels()[$key]) ? $this->getLabels()[$key] : FALSE;
+  }
+
+  /**
+   * Gets the value of creationTimestamp.
+   *
+   * @return string
+   *   Value of creationTimestamp.
+   */
+  public function getCreationTimestamp(): string {
+    return $this->creationTimestamp;
+  }
+
+  /**
+   * Sets the value of creationTimestamp.
+   *
+   * @param string $creationTimestamp
+   *   The value for creationTimestamp.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setCreationTimestamp(string $creationTimestamp) {
+    $this->creationTimestamp = $creationTimestamp;
+    return $this;
   }
 
 }

--- a/src/Objects/Backups/ObjectBase.php
+++ b/src/Objects/Backups/ObjectBase.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+use UniversityOfAdelaide\OpenShift\Objects\Label;
+
+/**
+ * A base class for objects.
+ */
+abstract class ObjectBase {
+
+  /**
+   * The name of the object.
+   *
+   * @var string
+   */
+  protected $name;
+
+  /**
+   * An array of labels.
+   *
+   * @var array
+   */
+  protected $labels = [];
+
+  /**
+   * Factory method for creating a new object.
+   *
+   * @return self
+   *   Returns static object.
+   */
+  public static function create() {
+    return new static();
+  }
+
+  /**
+   * Gets the value of name.
+   *
+   * @return string
+   *   Value of name.
+   */
+  public function getName(): string {
+    return $this->name;
+  }
+
+  /**
+   * Sets the name.
+   *
+   * @param string $name
+   *   The name of the object.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setName(string $name) {
+    $this->name = $name;
+    return $this;
+  }
+
+  /**
+   * Gets the value of labels.
+   *
+   * @return array
+   *   Value of labels.
+   */
+  public function getLabels(): array {
+    return $this->labels;
+  }
+
+  /**
+   * Sets the array of labels.
+   *
+   * @param array $labels
+   *   An array of labels.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setLabels(array $labels) {
+    $this->labels = $labels;
+    return $this;
+  }
+
+  /**
+   * Set a single label.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Label $label
+   *   The label object.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setLabel(Label $label) {
+    $this->labels[$label->getKey()] = $label->getValue();
+    return $this;
+  }
+
+  /**
+   * Get a single label.
+   *
+   * @param string $key
+   *   The key of the label.
+   *
+   * @return string|bool
+   *   The label value, or FALSE if it doesn't exist.
+   */
+  public function getLabel(string $key): string {
+    return isset($this->getLabels()[$key]) ? $this->getLabels()[$key] : FALSE;
+  }
+
+}

--- a/src/Objects/Backups/ObjectListBase.php
+++ b/src/Objects/Backups/ObjectListBase.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Base class for list objects.
+ */
+abstract class ObjectListBase {
+
+  /**
+   * Sorts an array of objects by created time.
+   *
+   * @param array $objects
+   *   The array of objects.
+   * @param string $operator
+   *   The sort operator.
+   *
+   * @return array
+   *   The sorted array.
+   */
+  protected function sortObjectsByCreationTime(array $objects, string $operator) {
+    usort($objects, function (ObjectBase $a, ObjectBase $b) use ($operator) {
+      return $operator === 'DESC' ? $a->getCreationTimestamp() < $b->getCreationTimestamp() : $a->getCreationTimestamp() > $b->getCreationTimestamp();
+    });
+    return $objects;
+  }
+
+}

--- a/src/Objects/Backups/Phase.php
+++ b/src/Objects/Backups/Phase.php
@@ -14,4 +14,17 @@ class Phase {
   const ENABLED = 'Enabled';
   const FAILED = 'Failed';
 
+  /**
+   * Returns the friendly name for a phase.
+   *
+   * @param string $phase
+   *   The phase string.
+   *
+   * @return string
+   *   The friendly string of the phase.
+   */
+  public static function getFriendlyPhase(string $phase) {
+    return implode(' ', preg_split('/(?<=[a-z])(?=[A-Z])|(?<=[A-Z])(?=[A-Z][a-z])/', $phase));
+  }
+
 }

--- a/src/Objects/Backups/Phase.php
+++ b/src/Objects/Backups/Phase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines phase constants.
+ */
+class Phase {
+
+  const NEW = 'New';
+  const FAILED_VALIDATION = 'FailedValidation';
+  const IN_PROGRESS = 'InProgress';
+  const COMPLETED = 'Completed';
+  const FAILED = 'Failed';
+
+}

--- a/src/Objects/Backups/Phase.php
+++ b/src/Objects/Backups/Phase.php
@@ -11,6 +11,7 @@ class Phase {
   const FAILED_VALIDATION = 'FailedValidation';
   const IN_PROGRESS = 'InProgress';
   const COMPLETED = 'Completed';
+  const ENABLED = 'Enabled';
   const FAILED = 'Failed';
 
 }

--- a/src/Objects/Backups/Restore.php
+++ b/src/Objects/Backups/Restore.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines a value object representing a Restore.
+ */
+class Restore extends BackupObjectBase {
+
+  /**
+   * The backup name that this restore is restoring from.
+   *
+   * @var string
+   */
+  protected $backupName;
+
+  /**
+   * Factory method for creating a new Backup.
+   *
+   * @return self
+   *   Returns static object.
+   */
+  public static function create() {
+    return new static();
+  }
+
+  /**
+   * Gets the value of backupName.
+   *
+   * @return string
+   *  Value of backupName.
+   */
+  public function getBackupName(): string {
+    return $this->backupName;
+  }
+
+  /**
+   * Sets the value of backupName.
+   *
+   * @param string $backupName
+   *  The value for backupName.
+   *
+   * @return Restore
+   *  The calling class.
+   */
+  public function setBackupName(string $backupName): Restore {
+    $this->backupName = $backupName;
+    return $this;
+  }
+
+}

--- a/src/Objects/Backups/Restore.php
+++ b/src/Objects/Backups/Restore.php
@@ -22,16 +22,6 @@ class Restore extends BackupObjectBase {
   protected $creationTimestamp;
 
   /**
-   * Factory method for creating a new Backup.
-   *
-   * @return self
-   *   Returns static object.
-   */
-  public static function create() {
-    return new static();
-  }
-
-  /**
    * Gets the value of backupName.
    *
    * @return string

--- a/src/Objects/Backups/Restore.php
+++ b/src/Objects/Backups/Restore.php
@@ -15,6 +15,15 @@ class Restore extends BackupObjectBase {
   protected $backupName;
 
   /**
+   * The name of the restore.
+   *
+   * We set this to an empty string by default so ark generates this for us.
+   *
+   * @var string
+   */
+  protected $name = '';
+
+  /**
    * Factory method for creating a new Backup.
    *
    * @return self

--- a/src/Objects/Backups/Restore.php
+++ b/src/Objects/Backups/Restore.php
@@ -15,15 +15,6 @@ class Restore extends BackupObjectBase {
   protected $backupName;
 
   /**
-   * The name of the restore.
-   *
-   * We set this to an empty string by default so ark generates this for us.
-   *
-   * @var string
-   */
-  protected $name = '';
-
-  /**
    * Factory method for creating a new Backup.
    *
    * @return self

--- a/src/Objects/Backups/Restore.php
+++ b/src/Objects/Backups/Restore.php
@@ -15,6 +15,13 @@ class Restore extends BackupObjectBase {
   protected $backupName;
 
   /**
+   * The time the restore was created.
+   *
+   * @var string
+   */
+  protected $creationTimestamp;
+
+  /**
    * Factory method for creating a new Backup.
    *
    * @return self
@@ -40,11 +47,35 @@ class Restore extends BackupObjectBase {
    * @param string $backupName
    *  The value for backupName.
    *
-   * @return Restore
+   * @return $this
    *  The calling class.
    */
   public function setBackupName(string $backupName): Restore {
     $this->backupName = $backupName;
+    return $this;
+  }
+
+  /**
+   * Gets the value of creationTimestamp.
+   *
+   * @return string
+   *  Value of creationTimestamp.
+   */
+  public function getCreationTimestamp(): string {
+    return $this->creationTimestamp;
+  }
+
+  /**
+   * Sets the value of creationTimestamp.
+   *
+   * @param string $creationTimestamp
+   *  The value for creationTimestamp.
+   *
+   * @return $this
+   *  The calling class.
+   */
+  public function setCreationTimestamp(string $creationTimestamp): Restore {
+    $this->creationTimestamp = $creationTimestamp;
     return $this;
   }
 

--- a/src/Objects/Backups/RestoreList.php
+++ b/src/Objects/Backups/RestoreList.php
@@ -28,10 +28,23 @@ class RestoreList {
    * Gets the restore list.
    *
    * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore[]
-   *  The list of restores.
+   *   The list of restores.
    */
   public function getRestores(): array {
     return $this->restores;
+  }
+
+  /**
+   * Gets a list of restores ordered by created time.
+   *
+   * @param string $operator
+   *   Which way to order the list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
+   *   The list of restores.
+   */
+  public function getRestoresByCreatedTime($operator = 'DESC'): array {
+    return $this->sortRestoresByStartTime($this->getRestores(), $operator);
   }
 
   /**
@@ -66,6 +79,24 @@ class RestoreList {
    */
   public function hasRestores():bool {
     return (bool) $this->getRestoreCount();
+  }
+
+  /**
+   * Sorts an array of restores by created time.
+   *
+   * @param array $restores
+   *   The array of restores.
+   * @param string $operator
+   *   The sort operator.
+   *
+   * @return array
+   *   The sorted array.
+   */
+  protected function sortRestoresByStartTime(array $restores, string $operator) {
+    usort($restores, function (Restore $a, Restore $b) use ($operator) {
+      return $operator === 'DESC' ? $a->getCreationTimestamp() < $b->getCreationTimestamp() : $a->getCreationTimestamp() > $b->getCreationTimestamp();
+    });
+    return $restores;
   }
 
 }

--- a/src/Objects/Backups/RestoreList.php
+++ b/src/Objects/Backups/RestoreList.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines a value object representing a RestoreList.
+ */
+class RestoreList {
+
+  /**
+   * The list of backups.
+   *
+   * @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore[]
+   */
+  protected $restores = [];
+
+  /**
+   * Factory method for creating a new RestoreList.
+   *
+   * @return self
+   *   Returns static object.
+   */
+  public static function create() {
+    return new static();
+  }
+
+  /**
+   * Gets the restore list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore[]
+   *  The list of restores.
+   */
+  public function getRestores(): array {
+    return $this->restores;
+  }
+
+  /**
+   * Adds a restore to the list.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore $restore
+   *   The restore to add to the list.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function addRestore(Restore $restore): RestoreList {
+    $this->restores[] = $restore;
+    return $this;
+  }
+
+  /**
+   * Gets the number of restores.
+   *
+   * @return int
+   *   The number of restores in this list.
+   */
+  public function getRestoreCount(): int {
+    return count($this->getRestores());
+  }
+
+  /**
+   * Checks there are restores in this list.
+   *
+   * @return bool
+   *   TRUE if there are any restores.
+   */
+  public function hasRestores():bool {
+    return (bool) $this->getRestoreCount();
+  }
+
+}

--- a/src/Objects/Backups/RestoreList.php
+++ b/src/Objects/Backups/RestoreList.php
@@ -5,7 +5,7 @@ namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
 /**
  * Defines a value object representing a RestoreList.
  */
-class RestoreList {
+class RestoreList extends ObjectListBase {
 
   /**
    * The list of backups.
@@ -40,11 +40,11 @@ class RestoreList {
    * @param string $operator
    *   Which way to order the list.
    *
-   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup[]
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore[]
    *   The list of restores.
    */
   public function getRestoresByCreatedTime($operator = 'DESC'): array {
-    return $this->sortRestoresByStartTime($this->getRestores(), $operator);
+    return $this->sortObjectsByCreationTime($this->getRestores(), $operator);
   }
 
   /**
@@ -79,24 +79,6 @@ class RestoreList {
    */
   public function hasRestores():bool {
     return (bool) $this->getRestoreCount();
-  }
-
-  /**
-   * Sorts an array of restores by created time.
-   *
-   * @param array $restores
-   *   The array of restores.
-   * @param string $operator
-   *   The sort operator.
-   *
-   * @return array
-   *   The sorted array.
-   */
-  protected function sortRestoresByStartTime(array $restores, string $operator) {
-    usort($restores, function (Restore $a, Restore $b) use ($operator) {
-      return $operator === 'DESC' ? $a->getCreationTimestamp() < $b->getCreationTimestamp() : $a->getCreationTimestamp() > $b->getCreationTimestamp();
-    });
-    return $restores;
   }
 
 }

--- a/src/Objects/Backups/ScheduledBackup.php
+++ b/src/Objects/Backups/ScheduledBackup.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Value object for scheduled backups.
+ */
+class ScheduledBackup extends BackupObjectBase {
+
+  /**
+   * The TTL for backups running on this schedule.
+   *
+   * @var string
+   */
+  protected $ttl = '720h0m0s';
+
+  /**
+   * An array of labels that must be matched to be included in the backups.
+   *
+   * @var array
+   */
+  protected $matchLabels = [];
+
+  /**
+   * Schedule as a Cron expression defining when to run the backups.
+   *
+   * @var string
+   */
+  protected $schedule;
+
+  /**
+   * Timestamp for when the last backup ran.
+   *
+   * @var string
+   */
+  protected $lastBackup;
+
+  /**
+   * Factory method for creating a new ScheduledBackup.
+   *
+   * @return self
+   *   Returns static object.
+   */
+  public static function create() {
+    return new static();
+  }
+
+  /**
+   * Gets the value of ttl.
+   *
+   * @return string
+   *   Value of ttl.
+   */
+  public function getTtl(): string {
+    return $this->ttl;
+  }
+
+  /**
+   * Sets the TTL.
+   *
+   * @param string $ttl
+   *   The ttl.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setTtl(string $ttl): ScheduledBackup {
+    $this->ttl = $ttl;
+    return $this;
+  }
+
+  /**
+   * Gets the value of matchLabels.
+   *
+   * @return array
+   *   Value of matchLabels.
+   */
+  public function getMatchLabels(): array {
+    return $this->matchLabels;
+  }
+
+  /**
+   * Sets the match labels.
+   *
+   * @param array $matchLabels
+   *   An array of labels.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setMatchLabels(array $matchLabels): ScheduledBackup {
+    $this->matchLabels = $matchLabels;
+    return $this;
+  }
+
+  /**
+   * Gets the value of schedule.
+   *
+   * @return string
+   *   Value of schedule.
+   */
+  public function getSchedule(): string {
+    return $this->schedule;
+  }
+
+  /**
+   * Sets the value of schedule.
+   *
+   * @param string $schedule
+   *   The value for schedule.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setSchedule(string $schedule): ScheduledBackup {
+    $this->schedule = $schedule;
+    return $this;
+  }
+
+  /**
+   * Gets the value of lastBackup.
+   *
+   * @return string
+   *   Value of lastBackup.
+   */
+  public function getLastBackup(): string {
+    return $this->lastBackup;
+  }
+
+  /**
+   * Sets the value of LastBackup.
+   *
+   * @param string $lastBackup
+   *   The value for lastBackup.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function setLastBackup(string $lastBackup): ScheduledBackup {
+    $this->lastBackup = $lastBackup;
+    return $this;
+  }
+
+}

--- a/src/Objects/Backups/ScheduledBackup.php
+++ b/src/Objects/Backups/ScheduledBackup.php
@@ -36,16 +36,6 @@ class ScheduledBackup extends BackupObjectBase {
   protected $lastBackup;
 
   /**
-   * Factory method for creating a new ScheduledBackup.
-   *
-   * @return self
-   *   Returns static object.
-   */
-  public static function create() {
-    return new static();
-  }
-
-  /**
    * Gets the value of ttl.
    *
    * @return string

--- a/src/Objects/Backups/Sync.php
+++ b/src/Objects/Backups/Sync.php
@@ -5,7 +5,7 @@ namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
 /**
  * Defines a value object representing a Sync.
  */
-class Sync extends ObjectBase {
+class Sync extends BackupObjectBase {
 
   /**
    * The source environment.
@@ -20,6 +20,13 @@ class Sync extends ObjectBase {
    * @var \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment
    */
   protected $target;
+
+  /**
+   * The time the sync was created.
+   *
+   * @var string
+   */
+  protected $creationTimestamp;
 
   /**
    * Create a sync object from a source and target env.
@@ -81,6 +88,30 @@ class Sync extends ObjectBase {
    */
   public function setTarget(SyncEnvironment $target): Sync {
     $this->target = $target;
+    return $this;
+  }
+
+  /**
+   * Gets the value of creationTimestamp.
+   *
+   * @return string
+   *   Value of creationTimestamp.
+   */
+  public function getCreationTimestamp(): string {
+    return $this->creationTimestamp;
+  }
+
+  /**
+   * Sets the value of creationTimestamp.
+   *
+   * @param string $creationTimestamp
+   *   The value for creationTimestamp.
+   *
+   * @return Sync
+   *   The calling class.
+   */
+  public function setCreationTimestamp(string $creationTimestamp): Sync {
+    $this->creationTimestamp = $creationTimestamp;
     return $this;
   }
 

--- a/src/Objects/Backups/Sync.php
+++ b/src/Objects/Backups/Sync.php
@@ -22,13 +22,6 @@ class Sync extends BackupObjectBase {
   protected $target;
 
   /**
-   * The time the sync was created.
-   *
-   * @var string
-   */
-  protected $creationTimestamp;
-
-  /**
    * Create a sync object from a source and target env.
    *
    * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment $source
@@ -88,30 +81,6 @@ class Sync extends BackupObjectBase {
    */
   public function setTarget(SyncEnvironment $target): Sync {
     $this->target = $target;
-    return $this;
-  }
-
-  /**
-   * Gets the value of creationTimestamp.
-   *
-   * @return string
-   *   Value of creationTimestamp.
-   */
-  public function getCreationTimestamp(): string {
-    return $this->creationTimestamp;
-  }
-
-  /**
-   * Sets the value of creationTimestamp.
-   *
-   * @param string $creationTimestamp
-   *   The value for creationTimestamp.
-   *
-   * @return Sync
-   *   The calling class.
-   */
-  public function setCreationTimestamp(string $creationTimestamp): Sync {
-    $this->creationTimestamp = $creationTimestamp;
     return $this;
   }
 

--- a/src/Objects/Backups/Sync.php
+++ b/src/Objects/Backups/Sync.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines a value object representing a Sync.
+ */
+class Sync extends ObjectBase {
+
+  /**
+   * The source environment.
+   *
+   * @var \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment
+   */
+  protected $source;
+
+  /**
+   * The target environment.
+   *
+   * @var \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment
+   */
+  protected $target;
+
+  /**
+   * Create a sync object from a source and target env.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment $source
+   *   The source env.
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment $target
+   *   The target env.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync
+   *   The sync object.
+   */
+  public static function createFromSourceAndTarget(SyncEnvironment $source, SyncEnvironment $target) {
+    return (new static())->setSource($source)->setTarget($target);
+  }
+
+  /**
+   * Gets the value of Source.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment
+   *   Value of Source.
+   */
+  public function getSource(): SyncEnvironment {
+    return $this->source;
+  }
+
+  /**
+   * Sets the value of Source.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment $source
+   *   The value for Source.
+   *
+   * @return Sync
+   *   The calling class.
+   */
+  public function setSource(SyncEnvironment $source): Sync {
+    $this->source = $source;
+    return $this;
+  }
+
+  /**
+   * Gets the value of Target.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment
+   *   Value of Target.
+   */
+  public function getTarget(): SyncEnvironment {
+    return $this->target;
+  }
+
+  /**
+   * Sets the value of Target.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment $target
+   *   The value for Target.
+   *
+   * @return Sync
+   *   The calling class.
+   */
+  public function setTarget(SyncEnvironment $target): Sync {
+    $this->target = $target;
+    return $this;
+  }
+
+}

--- a/src/Objects/Backups/SyncEnvironment.php
+++ b/src/Objects/Backups/SyncEnvironment.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines a value object representing a Sync environment.
+ */
+class SyncEnvironment extends ObjectBase {
+
+  /**
+   * The name of the pvc to sync for this environment.
+   *
+   * @var string
+   */
+  protected $persistentVolumeClaim;
+
+  /**
+   * The name of the secret to get credentials for this sync environment.
+   *
+   * @var string
+   */
+  protected $secret;
+
+  /**
+   * Create a SyncEnvironment from a pvc and secret string.
+   *
+   * @param string $pvc
+   *   The pvc name.
+   * @param string $secret
+   *   The secret name.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment
+   *   The resulting object.
+   */
+  public static function createFromPvcAndSecret(string $pvc, string $secret) {
+    return (new static())->setPersistentVolumeClaim($pvc)->setSecret($secret);
+  }
+
+  /**
+   * Gets the value of PersistentVolumeClaim.
+   *
+   * @return string
+   *   Value of PersistentVolumeClaim.
+   */
+  public function getPersistentVolumeClaim(): string {
+    return $this->persistentVolumeClaim;
+  }
+
+  /**
+   * Sets the value of PersistentVolumeClaim.
+   *
+   * @param string $persistentVolumeClaim
+   *   The value for PersistentVolumeClaim.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment
+   *   The calling class.
+   */
+  public function setPersistentVolumeClaim(string $persistentVolumeClaim): SyncEnvironment {
+    $this->persistentVolumeClaim = $persistentVolumeClaim;
+    return $this;
+  }
+
+  /**
+   * Gets the value of Secret.
+   *
+   * @return string
+   *   Value of Secret.
+   */
+  public function getSecret(): string {
+    return $this->secret;
+  }
+
+  /**
+   * Sets the value of Secret.
+   *
+   * @param string $secret
+   *   The value for Secret.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment
+   *   The calling class.
+   */
+  public function setSecret(string $secret): SyncEnvironment {
+    $this->secret = $secret;
+    return $this;
+  }
+
+}

--- a/src/Objects/Backups/SyncList.php
+++ b/src/Objects/Backups/SyncList.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects\Backups;
+
+/**
+ * Defines a value object representing a SyncList.
+ */
+class SyncList extends ObjectListBase {
+
+  /**
+   * The list of syncs.
+   *
+   * @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync[]
+   */
+  protected $syncs = [];
+
+  /**
+   * Factory method for creating a new SyncList.
+   *
+   * @return self
+   *   Returns static object.
+   */
+  public static function create() {
+    return new static();
+  }
+
+  /**
+   * Gets the sync list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync[]
+   *   The list of syncs.
+   */
+  public function getSyncs(): array {
+    return $this->syncs;
+  }
+
+  /**
+   * Gets a list of syncs ordered by created time.
+   *
+   * @param string $operator
+   *   Which way to order the list.
+   *
+   * @return \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync[]
+   *   The list of sorted syncs.
+   */
+  public function getSyncsByCreatedTime($operator = 'DESC'): array {
+    return $this->sortObjectsByCreationTime($this->getSyncs(), $operator);
+  }
+
+  /**
+   * Adds a sync to the list.
+   *
+   * @param \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync $sync
+   *   The sync to add to the list.
+   *
+   * @return $this
+   *   The calling class.
+   */
+  public function addSync(Sync $sync): SyncList {
+    $this->syncs[] = $sync;
+    return $this;
+  }
+
+  /**
+   * Gets the number of syncs.
+   *
+   * @return int
+   *   The number of backups in this list.
+   */
+  public function getSyncCount(): int {
+    return count($this->getSyncs());
+  }
+
+  /**
+   * Checks there are syncs in this list.
+   *
+   * @return bool
+   *   TRUE if there are any syncs.
+   */
+  public function hasSyncs():bool {
+    return (bool) $this->getSyncCount();
+  }
+
+}

--- a/src/Objects/Label.php
+++ b/src/Objects/Label.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Objects;
+
+/**
+ * Value object for a OS label.
+ */
+class Label {
+
+  /**
+   * The label key.
+   *
+   * @var string
+   */
+  protected $key;
+
+  /**
+   * The label value.
+   *
+   * @var string
+   */
+  protected $value;
+
+  public static function create(string $key, string $value) {
+    $instance = new static();
+    $instance->setKey($key)->setValue($value);
+    return $instance;
+  }
+
+  /**
+   * Gets the value of {Key}
+   *
+   * @return string
+   *  Value of {Key}
+   */
+  public function getKey(): string {
+    return $this->key;
+  }
+
+  /**
+   * Sets the value of Key
+   *
+   * @param string $key
+   *  The value for {Key}
+   *
+   * @return Label
+   *  The calling class.
+   */
+  public function setKey(string $key): Label {
+    $this->key = $key;
+    return $this;
+  }
+
+  /**
+   * Gets the value of {Value}
+   *
+   * @return string
+   *  Value of {Value}
+   */
+  public function getValue(): string {
+    return $this->value;
+  }
+
+  /**
+   * Sets the value of Value
+   *
+   * @param string $value
+   *  The value for {Value}
+   *
+   * @return Label
+   *  The calling class.
+   */
+  public function setValue(string $value): Label {
+    $this->value = $value;
+    return $this;
+  }
+
+  /**
+   * Turn the label into a string.
+   *
+   * @return string
+   */
+  public function __toString() {
+    return sprintf('%s=%s', $this->getKey(), $this->getValue());
+  }
+
+}

--- a/src/Serializer/BackupListNormalizer.php
+++ b/src/Serializer/BackupListNormalizer.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
+
+/**
+ * Serializer for BackupSet objects.
+ */
+class BackupListNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $supportedInterfaceOrClass = BackupList::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = NULL, array $context = []) {
+    $backups = BackupList::create();
+
+    foreach ($data['items'] as $backupData) {
+      $backups->addBackup($this->serializer->denormalize($backupData, Backup::class));
+    }
+
+    return $backups;
+
+  }
+
+}

--- a/src/Serializer/BackupListNormalizer.php
+++ b/src/Serializer/BackupListNormalizer.php
@@ -26,7 +26,6 @@ class BackupListNormalizer extends BaseNormalizer {
     }
 
     return $backups;
-
   }
 
 }

--- a/src/Serializer/BackupListNormalizer.php
+++ b/src/Serializer/BackupListNormalizer.php
@@ -6,7 +6,7 @@ use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
 
 /**
- * Serializer for BackupSet objects.
+ * Serializer for BackupList objects.
  */
 class BackupListNormalizer extends BaseNormalizer {
 

--- a/src/Serializer/BackupNormalizer.php
+++ b/src/Serializer/BackupNormalizer.php
@@ -22,6 +22,7 @@ class BackupNormalizer extends BaseNormalizer {
     $backup->setName($data['metadata']['name'])
       ->setLabels($data['metadata']['labels'])
       ->setTtl($data['spec']['ttl'])
+      ->setCreationTimestamp($data['metadata']['creationTimestamp'])
       ->setMatchLabels($data['spec']['labelSelector']['matchLabels']);
     if (isset($data['metadata']['annotations'])) {
       $backup->setAnnotations($data['metadata']['annotations']);

--- a/src/Serializer/BackupNormalizer.php
+++ b/src/Serializer/BackupNormalizer.php
@@ -25,10 +25,12 @@ class BackupNormalizer extends BaseNormalizer {
     ->setHooks([])
     ->setTtl($data['spec']['ttl'])
     ->setMatchLabels($data['spec']['labelSelector']['matchLabels'])
-    ->setPhase($data['status']['phase'])
     ->setStartTimestamp($data['status']['startTimestamp'])
     ->setCompletionTimestamp($data['status']['completionTimestamp'])
     ->setExpires($data['status']['expiration']);
+    if ($data['status']['phase']) {
+      $backup->setPhase($data['status']['phase']);
+    }
     return $backup;
   }
 

--- a/src/Serializer/BackupNormalizer.php
+++ b/src/Serializer/BackupNormalizer.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
+
+/**
+ * Serializer for Result objects.
+ */
+class BackupNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $supportedInterfaceOrClass = Backup::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = NULL, array $context = []) {
+    $backup = Backup::create();
+    $backup->setName($data['metadata']['name'])
+    ->setLabels($data['metadata']['labels'])
+    // @todo implement hooks.
+    ->setHooks([])
+    ->setTtl($data['spec']['ttl'])
+    ->setMatchLabels($data['spec']['labelSelector']['matchLabels'])
+    ->setPhase($data['status']['phase'])
+    ->setStartTimestamp($data['status']['startTimestamp'])
+    ->setCompletionTimestamp($data['status']['completionTimestamp'])
+    ->setExpires($data['status']['expiration']);
+    return $backup;
+  }
+
+}

--- a/src/Serializer/BackupNormalizer.php
+++ b/src/Serializer/BackupNormalizer.php
@@ -32,4 +32,34 @@ class BackupNormalizer extends BaseNormalizer {
     return $backup;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = []) {
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Backup $object */
+    $data = [
+      'apiVersion' => 'ark.heptio.com/v1',
+      'kind' => 'Backup',
+      'metadata' => [
+        'labels' => $object->getLabels(),
+        'name' =>  $object->getName(),
+        'namespace' => 'heptio-ark',
+      ],
+      'spec' => [
+        // @todo implement hooks.
+        'hooks'=> [
+          'resources'=> NULL,
+        ],
+        'labelSelector'=> [
+          'matchLabels'=> $object->getMatchLabels(),
+        ],
+        'storageLocation'=> 'default',
+        'ttl'=>  $object->getTtl(),
+        'volumeSnapshotLocations'=> null
+      ],
+    ];
+
+    return $data;
+  }
+
 }

--- a/src/Serializer/BackupNormalizer.php
+++ b/src/Serializer/BackupNormalizer.php
@@ -24,12 +24,18 @@ class BackupNormalizer extends BaseNormalizer {
     // @todo implement hooks.
     ->setHooks([])
     ->setTtl($data['spec']['ttl'])
-    ->setMatchLabels($data['spec']['labelSelector']['matchLabels'])
-    ->setStartTimestamp($data['status']['startTimestamp'])
-    ->setCompletionTimestamp($data['status']['completionTimestamp'])
-    ->setExpires($data['status']['expiration']);
-    if ($data['status']['phase']) {
+    ->setMatchLabels($data['spec']['labelSelector']['matchLabels']);
+    if (isset($data['status']['phase'])) {
       $backup->setPhase($data['status']['phase']);
+    }
+    if (isset($data['status']['startTimestamp'])) {
+      $backup->setStartTimestamp($data['status']['startTimestamp']);
+    }
+    if (isset($data['status']['completionTimestamp'])) {
+      $backup->setStartTimestamp($data['status']['completionTimestamp']);
+    }
+    if (isset($data['status']['expiration'])) {
+      $backup->setStartTimestamp($data['status']['expiration']);
     }
     return $backup;
   }

--- a/src/Serializer/BackupNormalizer.php
+++ b/src/Serializer/BackupNormalizer.php
@@ -32,10 +32,10 @@ class BackupNormalizer extends BaseNormalizer {
       $backup->setStartTimestamp($data['status']['startTimestamp']);
     }
     if (isset($data['status']['completionTimestamp'])) {
-      $backup->setStartTimestamp($data['status']['completionTimestamp']);
+      $backup->setCompletionTimestamp($data['status']['completionTimestamp']);
     }
     if (isset($data['status']['expiration'])) {
-      $backup->setStartTimestamp($data['status']['expiration']);
+      $backup->setExpires($data['status']['expiration']);
     }
     return $backup;
   }

--- a/src/Serializer/BackupNormalizer.php
+++ b/src/Serializer/BackupNormalizer.php
@@ -5,7 +5,7 @@ namespace UniversityOfAdelaide\OpenShift\Serializer;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 
 /**
- * Serializer for Result objects.
+ * Serializer for Backup objects.
  */
 class BackupNormalizer extends BaseNormalizer {
 

--- a/src/Serializer/BaseNormalizer.php
+++ b/src/Serializer/BaseNormalizer.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use Symfony\Component\Serializer\Normalizer\AbstractNormalizer;
+
+/**
+ * Base normalizer class.
+ */
+abstract class BaseNormalizer extends AbstractNormalizer {
+
+  use ClassNameSupportNormalizerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = []) {
+    throw new \RuntimeException("Method not implemented.");
+  }
+
+}

--- a/src/Serializer/ClassNameSupportNormalizerTrait.php
+++ b/src/Serializer/ClassNameSupportNormalizerTrait.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+/**
+ * Provides support for checking a class name for normalization support.
+ */
+trait ClassNameSupportNormalizerTrait {
+
+  /**
+   * The interface or class that this Normalizer supports.
+   *
+   * @var string|array
+   */
+  protected $supportedInterfaceOrClass;
+
+  /**
+   * Gets the string or array of supported classes.
+   *
+   * @return array|string
+   *   The string or array of supported classes.
+   */
+  public function getSupportedInterfaceOrClass() {
+    return $this->supportedInterfaceOrClass;
+  }
+
+  /**
+   * Sets the string or array of supported classes.
+   *
+   * @param array|string $supported_interface_or_class
+   *   The string or array of supported classes.
+   *
+   * @return $this
+   *   The current object.
+   */
+  public function setSupportedInterfaceOrClass($supported_interface_or_class) {
+    $this->supportedInterfaceOrClass = $supported_interface_or_class;
+    return $this;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsNormalization($data, $format = NULL) {
+    // If we aren't dealing with an object or the format is not supported return
+    // now.
+    if (!is_object($data)) {
+      return FALSE;
+    }
+
+    $supported = (array) $this->supportedInterfaceOrClass;
+
+    return (bool) array_filter($supported, function ($name) use ($data) {
+      return $data instanceof $name;
+    });
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function supportsDenormalization($data, $type, $format = NULL) {
+    $supported = (array) $this->supportedInterfaceOrClass;
+
+    $subclass_check = function ($name) use ($type) {
+      return (class_exists($name) || interface_exists($name)) && is_subclass_of($type,
+          $name, TRUE);
+    };
+
+    return in_array($type, $supported) || array_filter($supported,
+        $subclass_check);
+  }
+
+}

--- a/src/Serializer/OpenShiftSerializerFactory.php
+++ b/src/Serializer/OpenShiftSerializerFactory.php
@@ -25,6 +25,7 @@ class OpenShiftSerializerFactory {
       new BackupListNormalizer(),
       new RestoreNormalizer(),
       new RestoreListNormalizer(),
+      new ScheduledBackupNormalizer(),
     ];
     return new Serializer($normalizers, $encoders);
   }

--- a/src/Serializer/OpenShiftSerializerFactory.php
+++ b/src/Serializer/OpenShiftSerializerFactory.php
@@ -23,6 +23,7 @@ class OpenShiftSerializerFactory {
     $normalizers = [
       new BackupNormalizer(),
       new BackupListNormalizer(),
+      new RestoreNormalizer(),
     ];
     return new Serializer($normalizers, $encoders);
   }

--- a/src/Serializer/OpenShiftSerializerFactory.php
+++ b/src/Serializer/OpenShiftSerializerFactory.php
@@ -26,6 +26,7 @@ class OpenShiftSerializerFactory {
       new RestoreNormalizer(),
       new RestoreListNormalizer(),
       new ScheduledBackupNormalizer(),
+      new SyncNormalizer(),
     ];
     return new Serializer($normalizers, $encoders);
   }

--- a/src/Serializer/OpenShiftSerializerFactory.php
+++ b/src/Serializer/OpenShiftSerializerFactory.php
@@ -27,6 +27,7 @@ class OpenShiftSerializerFactory {
       new RestoreListNormalizer(),
       new ScheduledBackupNormalizer(),
       new SyncNormalizer(),
+      new SyncListNormalizer()
     ];
     return new Serializer($normalizers, $encoders);
   }

--- a/src/Serializer/OpenShiftSerializerFactory.php
+++ b/src/Serializer/OpenShiftSerializerFactory.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Creates a serializer for OS objects.
+ */
+class OpenShiftSerializerFactory {
+
+  /**
+   * Creates a Serializer object.
+   *
+   * @return \Symfony\Component\Serializer\Serializer
+   *   Returns the Serializer object.
+   */
+  public static function create() {
+    $encoders = [
+      new JsonEncoder(),
+    ];
+    $normalizers = [
+      new BackupNormalizer(),
+      new BackupListNormalizer(),
+    ];
+    return new Serializer($normalizers, $encoders);
+  }
+
+}

--- a/src/Serializer/OpenShiftSerializerFactory.php
+++ b/src/Serializer/OpenShiftSerializerFactory.php
@@ -24,6 +24,7 @@ class OpenShiftSerializerFactory {
       new BackupNormalizer(),
       new BackupListNormalizer(),
       new RestoreNormalizer(),
+      new RestoreListNormalizer(),
     ];
     return new Serializer($normalizers, $encoders);
   }

--- a/src/Serializer/RestoreListNormalizer.php
+++ b/src/Serializer/RestoreListNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\RestoreList;
+
+/**
+ * Serializer for RestoreList objects.
+ */
+class RestoreListNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $supportedInterfaceOrClass = RestoreList::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = NULL, array $context = []) {
+    $restores = RestoreList::create();
+
+    foreach ($data['items'] as $restoreData) {
+      $restores->addRestore($this->serializer->denormalize($restoreData, Restore::class));
+    }
+
+    return $restores;
+  }
+
+}

--- a/src/Serializer/RestoreNormalizer.php
+++ b/src/Serializer/RestoreNormalizer.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
+
+/**
+ * Serializer for Restore objects.
+ */
+class RestoreNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $supportedInterfaceOrClass = Restore::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = NULL, array $context = []) {
+    $backup = Restore::create();
+    $backup->setName($data['metadata']['name'])
+      ->setBackupName($data['spec']['backupName'])
+      ->setLabels($data['metadata']['labels']);
+    if (isset($data['status']['phase'])) {
+      $backup->setPhase($data['status']['phase']);
+    }
+    return $backup;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = []) {
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore $object */
+    $data = [
+      'apiVersion' => 'ark.heptio.com/v1',
+      'kind' => 'Restore',
+      'metadata' => [
+        'labels' => $object->getLabels(),
+        'name' =>  $object->getName(),
+        'namespace' => 'heptio-ark',
+      ],
+      'spec' => [
+        'backupName' => $object->getBackupName(),
+      ],
+    ];
+
+    return $data;
+  }
+
+}

--- a/src/Serializer/RestoreNormalizer.php
+++ b/src/Serializer/RestoreNormalizer.php
@@ -20,6 +20,7 @@ class RestoreNormalizer extends BaseNormalizer {
   public function denormalize($data, $class, $format = NULL, array $context = []) {
     $backup = Restore::create();
     $backup->setName($data['metadata']['name'])
+      ->setCreationTimestamp($data['metadata']['creationTimestamp'])
       ->setBackupName($data['spec']['backupName'])
       ->setLabels($data['metadata']['labels']);
     if (isset($data['status']['phase'])) {

--- a/src/Serializer/ScheduledBackupNormalizer.php
+++ b/src/Serializer/ScheduledBackupNormalizer.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup;
+
+/**
+ * Serializer for ScheduledBackup objects.
+ */
+class ScheduledBackupNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $supportedInterfaceOrClass = ScheduledBackup::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = NULL, array $context = []) {
+    $schedule = ScheduledBackup::create();
+    $schedule->setName($data['metadata']['name'])
+      ->setTtl($data['spec']['template']['ttl'])
+      ->setMatchLabels($data['spec']['template']['labelSelector']['matchLabels'])
+      ->setSchedule($data['spec']['schedule']);
+    if (isset($data['metadata']['labels'])) {
+      $schedule->setLabels($data['metadata']['labels']);
+    }
+    if (isset($data['status']['phase'])) {
+      $schedule->setPhase($data['status']['phase']);
+    }
+    if (isset($data['status']['lastBackup'])) {
+      $schedule->setLastBackup($data['status']['lastBackup']);
+    }
+    return $schedule;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = []) {
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup $object */
+    $data = [
+      'apiVersion' => 'ark.heptio.com/v1',
+      'kind' => 'Schedule',
+      'metadata' => [
+        'labels' => $object->getLabels(),
+        'name' => $object->getName(),
+        'namespace' => 'heptio-ark',
+      ],
+      'spec' => [
+        'schedule' => $object->getSchedule(),
+        'template' => [
+          'labelSelector' => [
+            'matchLabels' => $object->getMatchLabels(),
+          ],
+          'ttl' => $object->getTtl(),
+        ],
+      ],
+    ];
+
+    return $data;
+  }
+
+}

--- a/src/Serializer/SyncListNormalizer.php
+++ b/src/Serializer/SyncListNormalizer.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Sync;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\SyncList;
+
+/**
+ * Serializer for SyncList objects.
+ */
+class SyncListNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $supportedInterfaceOrClass = SyncList::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = NULL, array $context = []) {
+    $list = SyncList::create();
+
+    foreach ($data['items'] as $syncData) {
+      $list->addSync($this->serializer->denormalize($syncData, Sync::class));
+    }
+
+    return $list;
+  }
+
+}

--- a/src/Serializer/SyncNormalizer.php
+++ b/src/Serializer/SyncNormalizer.php
@@ -35,7 +35,7 @@ class SyncNormalizer extends BaseNormalizer {
   public function normalize($object, $format = NULL, array $context = []) {
     /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync $object */
     $data = [
-      'apiVersion' => 'environment.backups.shepherd/v1beta1',
+      'apiVersion' => 'workflow.shepherd/v1beta1',
       'kind' => 'Sync',
       'metadata' => [
         'labels' => $object->getLabels(),

--- a/src/Serializer/SyncNormalizer.php
+++ b/src/Serializer/SyncNormalizer.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Serializer;
+
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Sync;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment;
+
+/**
+ * Serializer for Sync objects.
+ */
+class SyncNormalizer extends BaseNormalizer {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $supportedInterfaceOrClass = Sync::class;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function denormalize($data, $class, $format = NULL, array $context = []) {
+    $sync = Sync::createFromSourceAndTarget(
+      SyncEnvironment::createFromPvcAndSecret($data['spec']['source']['persistentVolumeClaim'], $data['spec']['source']['secret']),
+      SyncEnvironment::createFromPvcAndSecret($data['spec']['target']['persistentVolumeClaim'], $data['spec']['target']['secret'])
+    )->setName($data['metadata']['name']);
+    if (isset($data['metadata']['labels'])) {
+      $sync->setLabels($data['metadata']['labels']);
+    }
+    return $sync;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function normalize($object, $format = NULL, array $context = []) {
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync $object */
+    $data = [
+      'apiVersion' => 'environment.backups.shepherd/v1beta1',
+      'kind' => 'Sync',
+      'metadata' => [
+        'labels' => $object->getLabels(),
+        'name' => $object->getName(),
+      ],
+      'spec' => [
+        'source' => [
+          'persistentVolumeClaim' => $object->getSource()->getPersistentVolumeClaim(),
+          'secret' => $object->getSource()->getSecret(),
+        ],
+        'target' => [
+          'persistentVolumeClaim' => $object->getTarget()->getPersistentVolumeClaim(),
+          'secret' => $object->getTarget()->getSecret(),
+        ],
+      ],
+    ];
+
+    return $data;
+  }
+
+}

--- a/src/Serializer/SyncNormalizer.php
+++ b/src/Serializer/SyncNormalizer.php
@@ -22,9 +22,14 @@ class SyncNormalizer extends BaseNormalizer {
     $sync = Sync::createFromSourceAndTarget(
       SyncEnvironment::createFromPvcAndSecret($data['spec']['source']['persistentVolumeClaim'], $data['spec']['source']['secret']),
       SyncEnvironment::createFromPvcAndSecret($data['spec']['target']['persistentVolumeClaim'], $data['spec']['target']['secret'])
-    )->setName($data['metadata']['name']);
+    )
+      ->setCreationTimestamp($data['metadata']['creationTimestamp'])
+      ->setName($data['metadata']['name']);
     if (isset($data['metadata']['labels'])) {
       $sync->setLabels($data['metadata']['labels']);
+    }
+    if (isset($data['status']['phase'])) {
+      $sync->setPhase($data['status']['phase']);
     }
     return $sync;
   }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * @file
+ * Boostrap for PHPUnit.
+ */
+assert_options(ASSERT_ACTIVE, FALSE);
+$autoloader = __DIR__ . '/../vendor/autoload.php';
+$loader = require $autoloader;
+if (!defined('PHPUNIT_COMPOSER_INSTALL')) {
+  define('PHPUNIT_COMPOSER_INSTALL', $autoloader);
+}

--- a/tests/fixtures/backup-list.json
+++ b/tests/fixtures/backup-list.json
@@ -219,7 +219,7 @@
       "status": {
         "completionTimestamp": "2018-11-22T04:39:28Z",
         "expiration": "2018-12-22T04:39:08Z",
-        "phase": "Completed",
+        "phase": "Failed",
         "startTimestamp": "2018-11-22T04:39:08Z",
         "validationErrors": null,
         "version": 1,

--- a/tests/fixtures/backup-list.json
+++ b/tests/fixtures/backup-list.json
@@ -8,6 +8,9 @@
         "clusterName": "",
         "creationTimestamp": "2018-11-22T00:05:22Z",
         "generation": 1,
+        "annotations": {
+          "some.annotation": "test 123"
+        },
         "labels": {
           "ark.heptio.com/storage-location": "default"
         },

--- a/tests/fixtures/backup-list.json
+++ b/tests/fixtures/backup-list.json
@@ -1,0 +1,234 @@
+{
+  "apiVersion": "ark.heptio.com/v1",
+  "items": [
+    {
+      "apiVersion": "ark.heptio.com/v1",
+      "kind": "Backup",
+      "metadata": {
+        "clusterName": "",
+        "creationTimestamp": "2018-11-22T00:05:22Z",
+        "generation": 1,
+        "labels": {
+          "ark.heptio.com/storage-location": "default"
+        },
+        "name": "node-5-backup",
+        "namespace": "heptio-ark",
+        "resourceVersion": "178206",
+        "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/backups/node-5-backup",
+        "uid": "4e19fcbc-edea-11e8-9746-0800273cb3d2"
+      },
+      "spec": {
+        "excludedNamespaces": null,
+        "excludedResources": null,
+        "hooks": {
+          "resources": null
+        },
+        "includeClusterResources": null,
+        "includedNamespaces": [
+          "*"
+        ],
+        "includedResources": null,
+        "labelSelector": {
+          "matchLabels": {
+            "app": "node-5"
+          }
+        },
+        "storageLocation": "default",
+        "ttl": "360h0m0s",
+        "volumeSnapshotLocations": null
+      },
+      "status": {
+        "completionTimestamp": "2018-11-21T00:16:43Z",
+        "expiration": "2018-12-21T00:16:23Z",
+        "phase": "Completed",
+        "startTimestamp": "2018-11-21T00:16:23Z",
+        "validationErrors": null,
+        "version": 1,
+        "volumeSnapshotsAttempted": 0,
+        "volumeSnapshotsCompleted": 0
+      }
+    },
+    {
+      "apiVersion": "ark.heptio.com/v1",
+      "kind": "Backup",
+      "metadata": {
+        "clusterName": "",
+        "creationTimestamp": "2018-11-22T00:03:50Z",
+        "generation": 1,
+        "labels": {
+          "ark.heptio.com/storage-location": "default"
+        },
+        "name": "node-7-backup",
+        "namespace": "heptio-ark",
+        "resourceVersion": "178100",
+        "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/backups/node-7-backup",
+        "uid": "175f47fa-edea-11e8-9746-0800273cb3d2"
+      },
+      "spec": {
+        "hooks": {
+          "resources": null
+        },
+        "labelSelector": {
+          "matchLabels": {
+            "app": "node-7"
+          }
+        },
+        "storageLocation": "default",
+        "ttl": "720h0m0s",
+        "volumeSnapshotLocations": null
+      },
+      "status": {
+        "completionTimestamp": "2018-11-22T00:04:26Z",
+        "expiration": "2018-12-22T00:03:50Z",
+        "phase": "Completed",
+        "startTimestamp": "2018-11-22T00:03:50Z",
+        "version": 1
+      }
+    },
+    {
+      "apiVersion": "ark.heptio.com/v1",
+      "kind": "Backup",
+      "metadata": {
+        "clusterName": "",
+        "creationTimestamp": "2018-11-22T00:05:22Z",
+        "generation": 1,
+        "labels": {
+          "ark.heptio.com/storage-location": "default"
+        },
+        "name": "node-7-backup2",
+        "namespace": "heptio-ark",
+        "resourceVersion": "178204",
+        "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/backups/node-7-backup2",
+        "uid": "4e17b728-edea-11e8-9746-0800273cb3d2"
+      },
+      "spec": {
+        "excludedNamespaces": null,
+        "excludedResources": null,
+        "hooks": {
+          "resources": null
+        },
+        "includeClusterResources": null,
+        "includedNamespaces": [
+          "*"
+        ],
+        "includedResources": null,
+        "labelSelector": {
+          "matchLabels": {
+            "app": "node-7"
+          }
+        },
+        "storageLocation": "default",
+        "ttl": "720h0m0s",
+        "volumeSnapshotLocations": null
+      },
+      "status": {
+        "completionTimestamp": "2018-11-21T22:40:27Z",
+        "expiration": "2018-12-21T22:40:00Z",
+        "phase": "Completed",
+        "startTimestamp": "2018-11-21T22:40:00Z",
+        "validationErrors": null,
+        "version": 1,
+        "volumeSnapshotsAttempted": 0,
+        "volumeSnapshotsCompleted": 0
+      }
+    },
+    {
+      "apiVersion": "ark.heptio.com/v1",
+      "kind": "Backup",
+      "metadata": {
+        "clusterName": "",
+        "creationTimestamp": "2018-11-22T00:05:22Z",
+        "generation": 1,
+        "labels": {
+          "ark.heptio.com/storage-location": "default"
+        },
+        "name": "node-7-backup3",
+        "namespace": "heptio-ark",
+        "resourceVersion": "178205",
+        "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/backups/node-7-backup3",
+        "uid": "4e18d93d-edea-11e8-9746-0800273cb3d2"
+      },
+      "spec": {
+        "excludedNamespaces": null,
+        "excludedResources": null,
+        "hooks": {
+          "resources": null
+        },
+        "includeClusterResources": null,
+        "includedNamespaces": null,
+        "includedResources": null,
+        "labelSelector": {
+          "matchLabels": {
+            "app": "node-7"
+          }
+        },
+        "storageLocation": "default",
+        "ttl": "720h0m0s",
+        "volumeSnapshotLocations": null
+      },
+      "status": {
+        "completionTimestamp": "2018-11-21T23:55:34Z",
+        "expiration": "2018-12-21T23:54:58Z",
+        "phase": "Completed",
+        "startTimestamp": "2018-11-21T23:54:58Z",
+        "validationErrors": null,
+        "version": 1,
+        "volumeSnapshotsAttempted": 0,
+        "volumeSnapshotsCompleted": 0
+      }
+    },
+    {
+      "apiVersion": "ark.heptio.com/v1",
+      "kind": "Backup",
+      "metadata": {
+        "clusterName": "",
+        "creationTimestamp": "2018-11-22T04:39:08Z",
+        "generation": 1,
+        "labels": {
+          "ark.heptio.com/storage-location": "default"
+        },
+        "name": "node-9-backup",
+        "namespace": "heptio-ark",
+        "resourceVersion": "210528",
+        "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/backups/node-9-backup",
+        "uid": "8d025876-ee10-11e8-9746-0800273cb3d2"
+      },
+      "spec": {
+        "excludedNamespaces": null,
+        "excludedResources": null,
+        "hooks": {
+          "resources": null
+        },
+        "includeClusterResources": null,
+        "includedNamespaces": [
+          "*"
+        ],
+        "includedResources": null,
+        "labelSelector": {
+          "matchLabels": {
+            "app": "node-9"
+          }
+        },
+        "storageLocation": "default",
+        "ttl": "720h0m0s",
+        "volumeSnapshotLocations": null
+      },
+      "status": {
+        "completionTimestamp": "2018-11-22T04:39:28Z",
+        "expiration": "2018-12-22T04:39:08Z",
+        "phase": "Completed",
+        "startTimestamp": "2018-11-22T04:39:08Z",
+        "validationErrors": null,
+        "version": 1,
+        "volumeSnapshotsAttempted": 0,
+        "volumeSnapshotsCompleted": 0
+      }
+    }
+  ],
+  "kind": "BackupList",
+  "metadata": {
+    "continue": "",
+    "resourceVersion": "226203",
+    "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/backups"
+  }
+}

--- a/tests/fixtures/backup.json
+++ b/tests/fixtures/backup.json
@@ -2,6 +2,9 @@
   "apiVersion": "ark.heptio.com/v1",
   "kind": "Backup",
   "metadata": {
+    "annotations": {
+      "some.annotation": "test 123"
+    },
     "labels": {
       "ark.heptio.com/storage-location": "default",
       "test-label": "test label value"
@@ -10,9 +13,6 @@
     "namespace": "heptio-ark"
   },
   "spec": {
-    "hooks": {
-      "resources": null
-    },
     "labelSelector": {
       "matchLabels": {
         "app": "test-123"

--- a/tests/fixtures/backup.json
+++ b/tests/fixtures/backup.json
@@ -1,0 +1,25 @@
+{
+  "apiVersion": "ark.heptio.com/v1",
+  "kind": "Backup",
+  "metadata": {
+    "labels": {
+      "ark.heptio.com/storage-location": "default",
+      "test-label": "test label value"
+    },
+    "name": "test-123-backup",
+    "namespace": "heptio-ark"
+  },
+  "spec": {
+    "hooks": {
+      "resources": null
+    },
+    "labelSelector": {
+      "matchLabels": {
+        "app": "test-123"
+      }
+    },
+    "storageLocation": "default",
+    "ttl": "100h20m0s",
+    "volumeSnapshotLocations": null
+  }
+}

--- a/tests/fixtures/restore-list.json
+++ b/tests/fixtures/restore-list.json
@@ -12,7 +12,7 @@
           "environment_id": "9",
           "site_id": "8"
         },
-        "name": "node-9-backup-20181126082338-20181126085223",
+        "name": "restore-1",
         "namespace": "heptio-ark",
         "resourceVersion": "289434",
         "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores/node-9-backup-20181126082338-20181126085223",
@@ -44,7 +44,7 @@
           "environment_id": "9",
           "site_id": "8"
         },
-        "name": "node-9-backup-20181126082338-20181126085525",
+        "name": "restore-3",
         "namespace": "heptio-ark",
         "resourceVersion": "289782",
         "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores/node-9-backup-20181126082338-20181126085525",
@@ -76,7 +76,7 @@
           "environment_id": "9",
           "site_id": "8"
         },
-        "name": "node-9-backup-20181126123820-20181126124258",
+        "name": "restore-2",
         "namespace": "heptio-ark",
         "resourceVersion": "315589",
         "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores/node-9-backup-20181126123820-20181126124258",

--- a/tests/fixtures/restore-list.json
+++ b/tests/fixtures/restore-list.json
@@ -1,0 +1,107 @@
+{
+  "apiVersion": "ark.heptio.com/v1",
+  "items": [
+    {
+      "apiVersion": "ark.heptio.com/v1",
+      "kind": "Restore",
+      "metadata": {
+        "clusterName": "",
+        "creationTimestamp": "2018-11-25T21:52:22Z",
+        "generation": 1,
+        "labels": {
+          "environment_id": "9",
+          "site_id": "8"
+        },
+        "name": "node-9-backup-20181126082338-20181126085223",
+        "namespace": "heptio-ark",
+        "resourceVersion": "289434",
+        "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores/node-9-backup-20181126082338-20181126085223",
+        "uid": "6350b879-f0fc-11e8-9452-0800273cb3d2"
+      },
+      "spec": {
+        "backupName": "node-9-backup-20181126082338",
+        "excludedResources": [
+          "nodes",
+          "events",
+          "events.events.k8s.io",
+          "backups.ark.heptio.com",
+          "restores.ark.heptio.com"
+        ]
+      },
+      "status": {
+        "phase": "Completed",
+        "warnings": 4
+      }
+    },
+    {
+      "apiVersion": "ark.heptio.com/v1",
+      "kind": "Restore",
+      "metadata": {
+        "clusterName": "",
+        "creationTimestamp": "2018-11-25T21:55:24Z",
+        "generation": 1,
+        "labels": {
+          "environment_id": "9",
+          "site_id": "8"
+        },
+        "name": "node-9-backup-20181126082338-20181126085525",
+        "namespace": "heptio-ark",
+        "resourceVersion": "289782",
+        "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores/node-9-backup-20181126082338-20181126085525",
+        "uid": "cfcd4111-f0fc-11e8-9452-0800273cb3d2"
+      },
+      "spec": {
+        "backupName": "node-9-backup-20181126082338",
+        "excludedResources": [
+          "nodes",
+          "events",
+          "events.events.k8s.io",
+          "backups.ark.heptio.com",
+          "restores.ark.heptio.com"
+        ]
+      },
+      "status": {
+        "phase": "Completed",
+        "warnings": 4
+      }
+    },
+    {
+      "apiVersion": "ark.heptio.com/v1",
+      "kind": "Restore",
+      "metadata": {
+        "clusterName": "",
+        "creationTimestamp": "2018-11-26T01:42:57Z",
+        "generation": 1,
+        "labels": {
+          "environment_id": "9",
+          "site_id": "8"
+        },
+        "name": "node-9-backup-20181126123820-20181126124258",
+        "namespace": "heptio-ark",
+        "resourceVersion": "315589",
+        "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores/node-9-backup-20181126123820-20181126124258",
+        "uid": "998cc149-f11c-11e8-9452-0800273cb3d2"
+      },
+      "spec": {
+        "backupName": "node-9-backup-20181126123820",
+        "excludedResources": [
+          "nodes",
+          "events",
+          "events.events.k8s.io",
+          "backups.ark.heptio.com",
+          "restores.ark.heptio.com"
+        ]
+      },
+      "status": {
+        "phase": "Completed",
+        "warnings": 4
+      }
+    }
+  ],
+  "kind": "RestoreList",
+  "metadata": {
+    "continue": "",
+    "resourceVersion": "323173",
+    "selfLink": "/apis/ark.heptio.com/v1/namespaces/heptio-ark/restores"
+  }
+}

--- a/tests/fixtures/restore.json
+++ b/tests/fixtures/restore.json
@@ -2,6 +2,7 @@
   "apiVersion": "ark.heptio.com/v1",
   "kind": "Restore",
   "metadata": {
+    "creationTimestamp": "2018-11-26T01:42:57Z",
     "labels": {
       "site_id": "123"
     },

--- a/tests/fixtures/restore.json
+++ b/tests/fixtures/restore.json
@@ -1,0 +1,17 @@
+{
+  "apiVersion": "ark.heptio.com/v1",
+  "kind": "Restore",
+  "metadata": {
+    "labels": {
+      "site_id": "123"
+    },
+    "name": "test-restore",
+    "namespace": "heptio-ark"
+  },
+  "spec": {
+    "backupName": "test-backup"
+  },
+  "status": {
+    "phase": "Completed"
+  }
+}

--- a/tests/fixtures/schedule.json
+++ b/tests/fixtures/schedule.json
@@ -1,0 +1,24 @@
+{
+  "apiVersion": "ark.heptio.com/v1",
+  "kind": "Schedule",
+  "metadata": {
+    "name": "test-schedule",
+    "labels": {},
+    "namespace": "heptio-ark"
+  },
+  "spec": {
+    "schedule": "*/5 * * * *",
+    "template": {
+      "labelSelector": {
+        "matchLabels": {
+          "app": "node-9"
+        }
+      },
+      "ttl": "360h0m0s"
+    }
+  },
+  "status": {
+    "lastBackup": "2018-11-29T05:00:47Z",
+    "phase": "Enabled"
+  }
+}

--- a/tests/fixtures/sync.json
+++ b/tests/fixtures/sync.json
@@ -1,7 +1,8 @@
 {
-  "apiVersion": "environment.backups.shepherd/v1beta1",
+  "apiVersion": "workflow.shepherd/v1beta1",
   "kind": "Sync",
   "metadata": {
+    "creationTimestamp": "2018-11-26T01:42:57Z",
     "name": "sync-sample",
     "labels": {}
   },
@@ -14,5 +15,8 @@
       "persistentVolumeClaim": "node-10-shared",
       "secret": "node-10"
     }
+  },
+  "status": {
+    "phase": "Completed"
   }
 }

--- a/tests/fixtures/sync.json
+++ b/tests/fixtures/sync.json
@@ -1,0 +1,18 @@
+{
+  "apiVersion": "environment.backups.shepherd/v1beta1",
+  "kind": "Sync",
+  "metadata": {
+    "name": "sync-sample",
+    "labels": {}
+  },
+  "spec": {
+    "source": {
+      "persistentVolumeClaim": "node-9-shared",
+      "secret": "node-9"
+    },
+    "target": {
+      "persistentVolumeClaim": "node-10-shared",
+      "secret": "node-10"
+    }
+  }
+}

--- a/tests/src/Unit/PhaseTest.php
+++ b/tests/src/Unit/PhaseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Phase;
+
+/**
+ * @coversDefaultClass \UniversityOfAdelaide\OpenShift\Objects\Backups\Phase
+ */
+class PhaseTest extends TestCase {
+
+  /**
+   * Tests getFriendlyPhase.
+   *
+   * @covers ::getFriendlyPhase
+   *
+   * @dataProvider providerTestGetFriendlyPhase
+   */
+  public function testGetFriendlyPhase($expected, $phase) {
+    $this->assertEquals($expected, Phase::getFriendlyPhase($phase));
+  }
+
+  /**
+   * Data provider for testGetFriendlyPhase.
+   *
+   * @return array
+   *   Array of values.
+   */
+  public function providerTestGetFriendlyPhase() {
+    return [
+      ['Completed', 'Completed'],
+      ['In Progress', 'InProgress'],
+      ['Failed Validation', 'FailedValidation'],
+      ['Completed', 'Completed'],
+      ['', ''],
+    ];
+  }
+
+}

--- a/tests/src/Unit/Serializer/BackupListSerializerTest.php
+++ b/tests/src/Unit/Serializer/BackupListSerializerTest.php
@@ -37,8 +37,32 @@ class BackupListSerializerTest extends TestCase {
     $this->assertTrue($backupList->hasBackups());
     $this->assertEquals(5, $backupList->getBackupCount());
     $this->assertCount(5, $backupList->getBackups());
-    $backupList->addBackup(Backup::create());
-    $this->assertEquals(6, $backupList->getBackupCount());
+    $this->assertCount(4, $backupList->getCompletedBackups());
+    $expected = [
+      'node-9-backup',
+      'node-7-backup',
+      'node-7-backup3',
+      'node-7-backup2',
+      'node-5-backup',
+    ];
+    $this->assertBackupOrder($expected, $backupList->getBackupsByStartTime());
+    $this->assertBackupOrder(array_reverse($expected), $backupList->getBackupsByStartTime('ASC'));
+    unset($expected[0]);
+    $this->assertBackupOrder(array_values($expected), $backupList->getCompletedBackupsByStartTime());
+  }
+
+  /**
+   * Test the order of backups by name.
+   *
+   * @param array $expected
+   *   The expected order.
+   * @param array $backups
+   *   The backups.
+   */
+  protected function assertBackupOrder(array $expected, array $backups) {
+    $this->assertEquals($expected, array_map(function (Backup $backup) {
+      return $backup->getName();
+    }, $backups));
   }
 
 }

--- a/tests/src/Unit/Serializer/BackupListSerializerTest.php
+++ b/tests/src/Unit/Serializer/BackupListSerializerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
+use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
+
+/**
+ * @coversDefaultClass \UniversityOfAdelaide\OpenShift\Serializer\BackupListNormalizer
+ */
+class BackupListSerializerTest extends TestCase {
+
+  /**
+   * The serializer.
+   *
+   * @var \UniversityOfAdelaide\OpenShift\Objects\Serializer\OpenShiftSerializerFactory
+   */
+  protected $serializer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->serializer = OpenShiftSerializerFactory::create();
+  }
+
+  /**
+   * @covers ::denormalize
+   */
+  public function testDenormalize() {
+    $jsonData = file_get_contents(__DIR__ . '/../../../fixtures/backup-list.json');
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList $backupList */
+    $backupList = $this->serializer->deserialize($jsonData, BackupList::class, 'json');
+    $this->assertTrue($backupList->hasBackups());
+    $this->assertEquals(5, $backupList->getBackupCount());
+    $this->assertCount(5, $backupList->getBackups());
+    $backupList->addBackup(Backup::create());
+    $this->assertEquals(6, $backupList->getBackupCount());
+  }
+
+}

--- a/tests/src/Unit/Serializer/BackupSerializerTest.php
+++ b/tests/src/Unit/Serializer/BackupSerializerTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Phase;
+use UniversityOfAdelaide\OpenShift\Objects\Label;
 use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
 
 /**
@@ -55,7 +56,7 @@ class BackupSerializerTest extends TestCase {
     $backup->setName('test-123-backup')
       ->setTtl('100h20m0s')
       ->setMatchLabels(['app' => 'test-123'])
-      ->setLabel('test-label', 'test label value');
+      ->setLabel(Label::create('test-label', 'test label value'));
 
     $expected = file_get_contents(__DIR__ . '/../../../fixtures/backup.json');
     $this->assertEquals(json_decode($expected), json_decode($this->serializer->serialize($backup, 'json')));

--- a/tests/src/Unit/Serializer/BackupSerializerTest.php
+++ b/tests/src/Unit/Serializer/BackupSerializerTest.php
@@ -39,13 +39,13 @@ class BackupSerializerTest extends TestCase {
     $backup = $backupList->getBackups()[0];
     $this->assertEquals('node-5-backup', $backup->getName());
     $this->assertEquals(['ark.heptio.com/storage-location' => 'default'], $backup->getLabels());
-    $this->assertEquals([], $backup->getHooks());
     $this->assertEquals('360h0m0s', $backup->getTtl());
     $this->assertEquals(['app' => 'node-5'], $backup->getMatchLabels());
     $this->assertEquals(Phase::COMPLETED, $backup->getPhase());
     $this->assertEquals('2018-11-21T00:16:23Z', $backup->getStartTimestamp());
     $this->assertEquals('2018-11-21T00:16:43Z', $backup->getCompletionTimestamp());
     $this->assertEquals('2018-12-21T00:16:23Z', $backup->getExpires());
+    $this->assertEquals('test 123', $backup->getAnnotation('some.annotation'));
   }
 
   /**
@@ -54,12 +54,17 @@ class BackupSerializerTest extends TestCase {
   public function testNormalizer() {
     $backup = Backup::create();
     $backup->setName('test-123-backup')
+      ->setAnnotation('some.annotation', 'test 123')
       ->setTtl('100h20m0s')
       ->setMatchLabels(['app' => 'test-123'])
       ->setLabel(Label::create('test-label', 'test label value'));
 
     $expected = file_get_contents(__DIR__ . '/../../../fixtures/backup.json');
     $this->assertEquals(json_decode($expected), json_decode($this->serializer->serialize($backup, 'json')));
+    // Ensure annotations aren't set when empty.
+    $backup = Backup::create()->setName('test 123');
+    $normalized = $this->serializer->normalize($backup);
+    $this->assertArrayNotHasKey('annotations', $normalized['metadata']);
   }
 
 }

--- a/tests/src/Unit/Serializer/BackupSerializerTest.php
+++ b/tests/src/Unit/Serializer/BackupSerializerTest.php
@@ -16,7 +16,7 @@ class BackupSerializerTest extends TestCase {
   /**
    * The serializer.
    *
-   * @var \UniversityOfAdelaide\OpenShift\Objects\Serializer\OpenShiftSerializerFactory
+   * @var \Symfony\Component\Serializer\Serializer
    */
   protected $serializer;
 
@@ -45,6 +45,20 @@ class BackupSerializerTest extends TestCase {
     $this->assertEquals('2018-11-21T00:16:23Z', $backup->getStartTimestamp());
     $this->assertEquals('2018-11-21T00:16:43Z', $backup->getCompletionTimestamp());
     $this->assertEquals('2018-12-21T00:16:23Z', $backup->getExpires());
+  }
+
+  /**
+   * @covers ::normalize
+   */
+  public function testNormalizer() {
+    $backup = Backup::create();
+    $backup->setName('test-123-backup')
+      ->setTtl('100h20m0s')
+      ->setMatchLabels(['app' => 'test-123'])
+      ->setLabel('test-label', 'test label value');
+
+    $expected = file_get_contents(__DIR__ . '/../../../fixtures/backup.json');
+    $this->assertEquals(json_decode($expected), json_decode($this->serializer->serialize($backup, 'json')));
   }
 
 }

--- a/tests/src/Unit/Serializer/BackupSerializerTest.php
+++ b/tests/src/Unit/Serializer/BackupSerializerTest.php
@@ -46,6 +46,7 @@ class BackupSerializerTest extends TestCase {
     $this->assertEquals('2018-11-21T00:16:43Z', $backup->getCompletionTimestamp());
     $this->assertEquals('2018-12-21T00:16:23Z', $backup->getExpires());
     $this->assertEquals('test 123', $backup->getAnnotation('some.annotation'));
+    $this->assertEquals('2018-11-22T00:05:22Z', $backup->getCreationTimestamp());
   }
 
   /**

--- a/tests/src/Unit/Serializer/BackupSerializerTest.php
+++ b/tests/src/Unit/Serializer/BackupSerializerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Phase;
+use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
+
+/**
+ * @coversDefaultClass \UniversityOfAdelaide\OpenShift\Serializer\BackupNormalizer
+ */
+class BackupSerializerTest extends TestCase {
+
+  /**
+   * The serializer.
+   *
+   * @var \UniversityOfAdelaide\OpenShift\Objects\Serializer\OpenShiftSerializerFactory
+   */
+  protected $serializer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->serializer = OpenShiftSerializerFactory::create();
+  }
+
+  /**
+   * @covers ::denormalize
+   */
+  public function testDenormalize() {
+    $jsonData = file_get_contents(__DIR__ . '/../../../fixtures/backup-list.json');
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList $backupList */
+    $backupList = $this->serializer->deserialize($jsonData, BackupList::class, 'json');
+    $backup = $backupList->getBackups()[0];
+    $this->assertEquals('node-5-backup', $backup->getName());
+    $this->assertEquals(['ark.heptio.com/storage-location' => 'default'], $backup->getLabels());
+    $this->assertEquals([], $backup->getHooks());
+    $this->assertEquals('360h0m0s', $backup->getTtl());
+    $this->assertEquals(['app' => 'node-5'], $backup->getMatchLabels());
+    $this->assertEquals(Phase::COMPLETED, $backup->getPhase());
+    $this->assertEquals('2018-11-21T00:16:23Z', $backup->getStartTimestamp());
+    $this->assertEquals('2018-11-21T00:16:43Z', $backup->getCompletionTimestamp());
+    $this->assertEquals('2018-12-21T00:16:23Z', $backup->getExpires());
+  }
+
+}

--- a/tests/src/Unit/Serializer/RestoreListSerializerTest.php
+++ b/tests/src/Unit/Serializer/RestoreListSerializerTest.php
@@ -37,8 +37,26 @@ class RestoreListSerializerTest extends TestCase {
     $this->assertTrue($restoreList->hasRestores());
     $this->assertEquals(3, $restoreList->getRestoreCount());
     $this->assertCount(3, $restoreList->getRestores());
-    $restoreList->addRestore(Restore::create());
-    $this->assertEquals(4, $restoreList->getRestoreCount());
+    $expected = [
+      'restore-2',
+      'restore-3',
+      'restore-1',
+    ];
+    $this->assertRestoreOrder($expected, $restoreList->getRestoresByCreatedTime());
+  }
+
+  /**
+   * Test the order of restores by name.
+   *
+   * @param array $expected
+   *   The expected order.
+   * @param array $restores
+   *   The restores.
+   */
+  protected function assertRestoreOrder(array $expected, array $restores) {
+    $this->assertEquals($expected, array_map(function (Restore $restore) {
+      return $restore->getName();
+    }, $restores));
   }
 
 }

--- a/tests/src/Unit/Serializer/RestoreListSerializerTest.php
+++ b/tests/src/Unit/Serializer/RestoreListSerializerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\RestoreList;
+use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
+
+/**
+ * @coversDefaultClass \UniversityOfAdelaide\OpenShift\Serializer\BackupListNormalizer
+ */
+class RestoreListSerializerTest extends TestCase {
+
+  /**
+   * The serializer.
+   *
+   * @var \UniversityOfAdelaide\OpenShift\Objects\Serializer\OpenShiftSerializerFactory
+   */
+  protected $serializer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->serializer = OpenShiftSerializerFactory::create();
+  }
+
+  /**
+   * @covers ::denormalize
+   */
+  public function testDenormalize() {
+    $jsonData = file_get_contents(__DIR__ . '/../../../fixtures/restore-list.json');
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\RestoreList $restoreList */
+    $restoreList = $this->serializer->deserialize($jsonData, RestoreList::class, 'json');
+    $this->assertTrue($restoreList->hasRestores());
+    $this->assertEquals(3, $restoreList->getRestoreCount());
+    $this->assertCount(3, $restoreList->getRestores());
+    $restoreList->addRestore(Restore::create());
+    $this->assertEquals(4, $restoreList->getRestoreCount());
+  }
+
+}

--- a/tests/src/Unit/Serializer/RestoreSerializerTest.php
+++ b/tests/src/Unit/Serializer/RestoreSerializerTest.php
@@ -5,6 +5,7 @@ namespace UniversityOfAdelaide\OpenShift\Tests\Unit\Serializer;
 use PHPUnit\Framework\TestCase;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Phase;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
+use UniversityOfAdelaide\OpenShift\Objects\Label;
 use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
 
 /**
@@ -47,7 +48,7 @@ class RestoreSerializerTest extends TestCase {
     $restore = Restore::create();
     $restore->setName('test-restore')
       ->setBackupName('test-backup')
-      ->setLabel('site_id', '123');
+      ->setLabel(Label::create('site_id', '123'));
 
     $expected = file_get_contents(__DIR__ . '/../../../fixtures/restore.json');
     $expected = json_decode($expected, TRUE);

--- a/tests/src/Unit/Serializer/RestoreSerializerTest.php
+++ b/tests/src/Unit/Serializer/RestoreSerializerTest.php
@@ -39,14 +39,15 @@ class RestoreSerializerTest extends TestCase {
     $this->assertEquals('test-backup', $restore->getBackupName());
     $this->assertEquals(['site_id' => '123'], $restore->getLabels());
     $this->assertEquals(Phase::COMPLETED, $restore->getPhase());
+    $this->assertEquals('2018-11-26T01:42:57Z', $restore->getCreationTimestamp());
   }
 
   /**
    * @covers ::normalize
    */
   public function testNormalizer() {
-    $restore = Restore::create();
-    $restore->setName('test-restore')
+    $restore = Restore::create()
+      ->setName('test-restore')
       ->setBackupName('test-backup')
       ->setLabel(Label::create('site_id', '123'));
 
@@ -54,6 +55,7 @@ class RestoreSerializerTest extends TestCase {
     $expected = json_decode($expected, TRUE);
     // We don't set status on normalization.
     unset($expected['status']);
+    unset($expected['metadata']['creationTimestamp']);
     $this->assertEquals($expected, json_decode($this->serializer->serialize($restore, 'json'), TRUE));
   }
 

--- a/tests/src/Unit/Serializer/RestoreSerializerTest.php
+++ b/tests/src/Unit/Serializer/RestoreSerializerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Phase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Restore;
+use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
+
+/**
+ * @coversDefaultClass \UniversityOfAdelaide\OpenShift\Serializer\RestoreNormalizer
+ */
+class RestoreSerializerTest extends TestCase {
+
+  /**
+   * The serializer.
+   *
+   * @var \Symfony\Component\Serializer\Serializer
+   */
+  protected $serializer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->serializer = OpenShiftSerializerFactory::create();
+  }
+
+  /**
+   * @covers ::denormalize
+   */
+  public function testDenormalize() {
+    $jsonData = file_get_contents(__DIR__ . '/../../../fixtures/restore.json');
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Restore $restore */
+    $restore = $this->serializer->deserialize($jsonData, Restore::class, 'json');
+    $this->assertEquals('test-restore', $restore->getName());
+    $this->assertEquals('test-backup', $restore->getBackupName());
+    $this->assertEquals(['site_id' => '123'], $restore->getLabels());
+    $this->assertEquals(Phase::COMPLETED, $restore->getPhase());
+  }
+
+  /**
+   * @covers ::normalize
+   */
+  public function testNormalizer() {
+    $restore = Restore::create();
+    $restore->setName('test-restore')
+      ->setBackupName('test-backup')
+      ->setLabel('site_id', '123');
+
+    $expected = file_get_contents(__DIR__ . '/../../../fixtures/restore.json');
+    $expected = json_decode($expected, TRUE);
+    // We don't set status on normalization.
+    unset($expected['status']);
+    $this->assertEquals($expected, json_decode($this->serializer->serialize($restore, 'json'), TRUE));
+  }
+
+}

--- a/tests/src/Unit/Serializer/ScheduledBackupSerializerTest.php
+++ b/tests/src/Unit/Serializer/ScheduledBackupSerializerTest.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Phase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup;
+use UniversityOfAdelaide\OpenShift\Objects\Label;
+use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
+
+/**
+ * @coversDefaultClass \UniversityOfAdelaide\OpenShift\Serializer\ScheduledBackupNormalizer
+ */
+class ScheduledBackupSerializerTest extends TestCase {
+
+  /**
+   * The serializer.
+   *
+   * @var \Symfony\Component\Serializer\Serializer
+   */
+  protected $serializer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->serializer = OpenShiftSerializerFactory::create();
+  }
+
+  /**
+   * @covers ::denormalize
+   */
+  public function testDenormalize() {
+    $jsonData = file_get_contents(__DIR__ . '/../../../fixtures/schedule.json');
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup $schedule */
+    $schedule = $this->serializer->deserialize($jsonData, ScheduledBackup::class, 'json');
+    $this->assertEquals('test-schedule', $schedule->getName());
+    $this->assertEquals('360h0m0s', $schedule->getTtl());
+    $this->assertEquals(['app' => 'node-9'], $schedule->getMatchLabels());
+    $this->assertEquals(Phase::ENABLED, $schedule->getPhase());
+    $this->assertEquals('2018-11-29T05:00:47Z', $schedule->getLastBackup());
+    $this->assertEquals('*/5 * * * *', $schedule->getSchedule());
+  }
+
+  /**
+   * @covers ::normalize
+   */
+  public function testNormalizer() {
+    $backup = ScheduledBackup::create();
+    $backup->setName('test-schedule')
+      ->setTtl('360h0m0s')
+      ->setMatchLabels(['app' => 'node-9'])
+      ->setLastBackup('2018-11-29T05:00:47Z')
+      ->setSchedule('*/5 * * * *')
+      ->setPhase(Phase::ENABLED);
+
+    $expected = json_decode(file_get_contents(__DIR__ . '/../../../fixtures/schedule.json'), TRUE);
+    unset($expected['status']);
+    $this->assertEquals($expected, $this->serializer->normalize($backup));
+  }
+
+}

--- a/tests/src/Unit/Serializer/ScheduledBackupSerializerTest.php
+++ b/tests/src/Unit/Serializer/ScheduledBackupSerializerTest.php
@@ -3,11 +3,8 @@
 namespace UniversityOfAdelaide\OpenShift\Tests\Unit\Serializer;
 
 use PHPUnit\Framework\TestCase;
-use UniversityOfAdelaide\OpenShift\Objects\Backups\Backup;
-use UniversityOfAdelaide\OpenShift\Objects\Backups\BackupList;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\Phase;
 use UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup;
-use UniversityOfAdelaide\OpenShift\Objects\Label;
 use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
 
 /**

--- a/tests/src/Unit/Serializer/SyncSerializerTest.php
+++ b/tests/src/Unit/Serializer/SyncSerializerTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace UniversityOfAdelaide\OpenShift\Tests\Unit\Serializer;
+
+use PHPUnit\Framework\TestCase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Phase;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\ScheduledBackup;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\Sync;
+use UniversityOfAdelaide\OpenShift\Objects\Backups\SyncEnvironment;
+use UniversityOfAdelaide\OpenShift\Serializer\OpenShiftSerializerFactory;
+
+/**
+ * @coversDefaultClass \UniversityOfAdelaide\OpenShift\Serializer\SyncNormalizer
+ */
+class SyncSerializerTest extends TestCase {
+
+  /**
+   * The serializer.
+   *
+   * @var \Symfony\Component\Serializer\Serializer
+   */
+  protected $serializer;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setUp() {
+    parent::setUp();
+    $this->serializer = OpenShiftSerializerFactory::create();
+  }
+
+  /**
+   * @covers ::denormalize
+   */
+  public function testDenormalize() {
+    $jsonData = file_get_contents(__DIR__ . '/../../../fixtures/sync.json');
+    /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Sync $sync */
+    $sync = $this->serializer->deserialize($jsonData, Sync::class, 'json');
+    $this->assertEquals('sync-sample', $sync->getName());
+    $this->assertEquals('node-9-shared', $sync->getSource()->getPersistentVolumeClaim());
+    $this->assertEquals('node-9', $sync->getSource()->getSecret());
+    $this->assertEquals('node-10-shared', $sync->getTarget()->getPersistentVolumeClaim());
+    $this->assertEquals('node-10', $sync->getTarget()->getSecret());
+  }
+
+  /**
+   * @covers ::normalize
+   */
+  public function testNormalizer() {
+    $sync = Sync::createFromSourceAndTarget(
+      SyncEnvironment::createFromPvcAndSecret('node-9-shared', 'node-9'),
+      SyncEnvironment::createFromPvcAndSecret('node-10-shared', 'node-10')
+    )->setName('sync-sample');
+
+    $expected = json_decode(file_get_contents(__DIR__ . '/../../../fixtures/sync.json'), TRUE);
+    $this->assertEquals($expected, $this->serializer->normalize($sync));
+  }
+
+}

--- a/tests/src/Unit/Serializer/SyncSerializerTest.php
+++ b/tests/src/Unit/Serializer/SyncSerializerTest.php
@@ -41,6 +41,8 @@ class SyncSerializerTest extends TestCase {
     $this->assertEquals('node-9', $sync->getSource()->getSecret());
     $this->assertEquals('node-10-shared', $sync->getTarget()->getPersistentVolumeClaim());
     $this->assertEquals('node-10', $sync->getTarget()->getSecret());
+    $this->assertEquals('2018-11-26T01:42:57Z', $sync->getCreationTimestamp());
+    $this->assertEquals('Completed', $sync->getPhase());
   }
 
   /**
@@ -50,9 +52,11 @@ class SyncSerializerTest extends TestCase {
     $sync = Sync::createFromSourceAndTarget(
       SyncEnvironment::createFromPvcAndSecret('node-9-shared', 'node-9'),
       SyncEnvironment::createFromPvcAndSecret('node-10-shared', 'node-10')
-    )->setName('sync-sample');
+    )->setCreationTimestamp('2018-11-26T01:42:57Z')->setName('sync-sample');
 
     $expected = json_decode(file_get_contents(__DIR__ . '/../../../fixtures/sync.json'), TRUE);
+    unset($expected['status']);
+    unset($expected['metadata']['creationTimestamp']);
     $this->assertEquals($expected, $this->serializer->normalize($sync));
   }
 


### PR DESCRIPTION
This PR does the following:

- Adds client support for Ark Backup objects
- Adds client support for Ark Restore objects
- Adds client support for Ark Schedule objects
- Adds client support for custom Sync objects (https://gitlab.adelaide.edu.au/web-team/shepherd-environment-sync)
- All new objects are done via symfony serialzation plugins via the normalizers, this gives us much better flexibility in terms of getting the data in and out of openshift.

What this PR doesn't do:
- Unit tests, there's a lot of new code here which would be great to test but with the lack of unit tests in the project currently I've pretty much run out of time to get this set up. There are however tests covering all of the serialization so the bulk of the work is already covered through that.
- To achieve proper unit testing we need to refactor the client class and make the Guzzle client injectable in order to mock it in a test. That way we can just make the guzzle client return our fixtures and properly unit test all of our logic inside all of the resource functions etc.