### PR TITLE
Feature/openshift 311 support

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1492,13 +1492,18 @@ class Client implements ClientInterface {
                 ],
               'dnsPolicy' => 'ClusterFirst',
               'restartPolicy' => 'Never',
-              'securityContext' => [],
               'terminationGracePeriodSeconds' => 30,
               'volumes' => $volume_config['config'],
             ],
         ],
       ],
     ];
+
+    // v3.11 complains if the securityContext is blank, only create if needed.
+    if (array_key_exists('uid', $data)) {
+      $job_template['spec']['template']['spec'] +=
+        $this->generateSecurityContext($data);
+    }
 
     return $job_template;
   }

--- a/src/Client.php
+++ b/src/Client.php
@@ -1029,6 +1029,7 @@ class Client implements ClientInterface {
    * Return an array of probes.
    *
    * @param $probes
+   *  Array of probe configuration constructed from a project entity.
    *
    * @return array
    *   Probes array ready for API.


### PR DESCRIPTION
Openshft 3.11 API is a little more picky, and doesn't support empty parameters.
Change the client so that it only passes in things when they have a value for deploymentconfig and job template.