### PR TITLE
Filter out empty array parameters to stop openshift errors.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -328,11 +328,28 @@ class Client implements ClientInterface {
     return $this->guzzleClient;
   }
 
+  public function filterEmptyArrays($array) {
+    foreach ($array as $key => $value) {
+      if (is_array($value)) {
+        if (empty($value)) {
+          unset($array[$key]);
+        }
+        else {
+          $array[$key] = $this->filterEmptyArrays($value);
+        }
+      }
+    }
+    return $array;
+  }
+
   /**
    * {@inheritdoc}
    */
   public function request(string $method, string $uri, array $body = [], array $query = []) {
     $requestOptions = [];
+
+    // Openshift API borks on empty array parameters, remove them.
+    $body = $this->filterEmptyArrays($body);
 
     if ($method !== 'DELETE') {
       $requestOptions = [

--- a/src/Client.php
+++ b/src/Client.php
@@ -328,7 +328,16 @@ class Client implements ClientInterface {
     return $this->guzzleClient;
   }
 
-  public function filterEmptyArrays($array) {
+  /**
+   * Recurse into the array and remove any keys with empty values.
+   *
+   * @param array $array
+   *   The array to process.
+   *
+   * @return array
+   *   The processed array with empty data removed.
+   */
+  private function filterEmptyArrays(array $array) {
     foreach ($array as $key => $value) {
       if (is_array($value)) {
         if (empty($value)) {


### PR DESCRIPTION
I was removing things from various parts of the shepherd code, but doing it in the client makes more sense or it will be like whack a mole.