### PR TITLE
Feature/sapp 343 delete schedule only

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1618,8 +1618,14 @@ class Client implements ClientInterface {
   /**
    * {@inheritdoc}
    */
-  public function deleteSchedule(string $name) {
-    return $this->apiCall(__METHOD__, $name);
+  public function deleteSchedule(string $name, bool $cascade = FALSE) {
+    $resourceMethod = $this->getResourceMethod(__METHOD__);
+    $uri = $this->createRequestUri($resourceMethod['uri'], [
+      'name' => $name,
+    ]);
+    // @link https://kubernetes.io/docs/concepts/workloads/controllers/garbage-collection/
+    $body = $cascade ? NULL : '{"kind":"DeleteOptions","apiVersion":"v1","propagationPolicy":"Orphan"}';
+    return $this->request($resourceMethod['action'], $uri, $body);
   }
 
   /**

--- a/src/Client.php
+++ b/src/Client.php
@@ -474,12 +474,10 @@ class Client implements ClientInterface {
       $body = $this->filterEmptyArrays($body);
     }
 
-    if ($method !== 'DELETE') {
-      $requestOptions = [
-        'query' => $query,
-        'body' => is_array($body) ? json_encode($body) : $body,
-      ];
-    }
+    $requestOptions = [
+      'query' => $query,
+      'body' => is_array($body) ? json_encode($body) : $body,
+    ];
 
     if ($method === 'PATCH') {
       $requestOptions['headers']['Content-Type'] = 'application/merge-patch+json';

--- a/src/Client.php
+++ b/src/Client.php
@@ -1873,7 +1873,7 @@ class Client implements ClientInterface {
       $query = ['labelSelector' => $label];
     }
 
-    return $this->request($resourceMethod['action'], $uri, [], $query, $decode_response);
+    return $this->request($resourceMethod['action'], $uri, NULL, $query, $decode_response);
   }
 
 }

--- a/src/ClientInterface.php
+++ b/src/ClientInterface.php
@@ -1035,6 +1035,8 @@ interface ClientInterface {
    *
    * @param string $name
    *   The name schedule to delete.
+   * @param bool $cascade
+   *   By default, don't delete all backups associated with a backup schedule.
    *
    * @return array
    *   Returns the body response if successful.
@@ -1042,7 +1044,7 @@ interface ClientInterface {
    * @throws ClientException
    *   Throws exception if there is an issue deleting schedule.
    */
-  public function deleteSchedule(string $name);
+  public function deleteSchedule(string $name, bool $cascade = FALSE);
 
   /**
    * Updates an existing configmap.


### PR DESCRIPTION
For https://github.com/universityofadelaide/shepherd/pull/154

* DELETE method should be allowed to have a request body.
* Deleting a schedule shouldn't delete all the child objects (backups). Pass in the cascade: false option.