### PR TITLE
Adds missing object structures to the test fixtures and set retention…

### DIFF
--- a/.github/workflows/shepherd-operator.yml
+++ b/.github/workflows/shepherd-operator.yml
@@ -1,0 +1,37 @@
+# GitHub Action for Shepherd Operator
+name: Testing Shepherd Operator
+on: [push, pull_request]
+jobs:
+  symfony:
+    name: Shepherd Operator (PHP ${{ matrix.php-versions }} on ${{ matrix.operating-system }})
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      fail-fast: false
+      matrix:
+        operating-system: [ubuntu-latest]
+        php-versions: ['7.4']
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Setup PHP, with composer and extensions
+        uses: shivammathur/setup-php@v2 #https://github.com/shivammathur/setup-php
+        with:
+          php-version: ${{ matrix.php-versions }}
+          extensions: mbstring
+          coverage: xdebug #optional
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "::set-output name=dir::$(composer config cache-files-dir)"
+      - name: Cache composer dependencies
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          # Use composer.json for key, if composer.lock is not committed.
+          # key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.json') }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+      - name: Install Composer dependencies
+        run: |
+          composer install --no-progress --prefer-dist
+      - name: Run Tests
+        run: vendor/phpunit/phpunit/phpunit --coverage-text tests/src/Unit/

--- a/tests/fixtures/route.json
+++ b/tests/fixtures/route.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "route.openshift.io/v1",
+  "apiVersion": "v1",
   "kind": "Route",
   "metadata": {
     "name": "route-test"

--- a/tests/fixtures/schedule.json
+++ b/tests/fixtures/schedule.json
@@ -9,7 +9,9 @@
     }
   },
   "spec": {
-    "schedule": "0 2 * * * *",
+    "schedule": {
+      "crontab": "0 2 * * *"
+    },
     "volumes": {
       "shared": {
         "claimName": "node-123-shared"
@@ -28,6 +30,9 @@
           }
         }
       }
+    },
+    "retention": {
+      "maxNumber": 7
     }
   },
   "status": {

--- a/tests/src/Unit/Serializer/ScheduledBackupSerializerTest.php
+++ b/tests/src/Unit/Serializer/ScheduledBackupSerializerTest.php
@@ -39,7 +39,7 @@ class ScheduledBackupSerializerTest extends TestCase {
     $this->assertEquals(['test-label' => 'test label value'], $schedule->getLabels());
     $this->assertEquals('test-schedule', $schedule->getName());
     $this->assertEquals('2018-11-21T00:16:43Z', $schedule->getLastExecuted());
-    $this->assertEquals('0 2 * * * *', $schedule->getSchedule());
+    $this->assertEquals('0 2 * * *', $schedule->getSchedule());
     $this->assertEquals(['shared' => 'node-123-shared'], $schedule->getVolumes());
     /** @var \UniversityOfAdelaide\OpenShift\Objects\Backups\Database $db */
     $db = $schedule->getDatabases()[0];
@@ -75,7 +75,8 @@ class ScheduledBackupSerializerTest extends TestCase {
       ])
       ->addDatabase($db)
       ->setLastExecuted('2018-11-29T05:00:47Z')
-      ->setSchedule('0 2 * * * *')
+      ->setSchedule('0 2 * * *')
+      ->setRetention(7)
       ->setLabel(Label::create('test-label', 'test label value'));
 
     $expected = json_decode(file_get_contents(__DIR__ . '/../../../fixtures/schedule.json'), TRUE);


### PR DESCRIPTION
… where needed.

Actually runs the tests now via github actions.

Followed example @ https://github.com/shivammathur/setup-php/blob/master/examples/symfony.yml
Ran locally using https://github.com/nektos/act