### PR TITLE
Set the default imagePullPolicy to IfNotPresent.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -1922,7 +1922,7 @@ class Client implements ClientInterface {
                     'args' => $args,
                     'env' => $data['env_vars'] ?? [],
                     'image' => $image_name,
-                    'imagePullPolicy' => 'Always',
+                    'imagePullPolicy' => 'IfNotPresent',
                     'name' => $name,
                     'resources' =>
                       [


### PR DESCRIPTION
Should reduce load during cronjobs, where it's supposedly pulling down the whole image (I believe it's only manifest, but going off S&S advice).